### PR TITLE
Priority Group Selector Extension

### DIFF
--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -16,7 +16,7 @@ import TwitchChannelPointsMiner.classes.websocket.hermes.data as hermes_data
 from TwitchChannelPointsMiner.classes.Chat import ChatPresence, ThreadChat
 from TwitchChannelPointsMiner.classes.Exceptions import StreamerDoesNotExistException
 from TwitchChannelPointsMiner.classes.PubSub import PubSubHandler
-from TwitchChannelPointsMiner.classes.Settings import FollowersOrder, Priority, Settings
+from TwitchChannelPointsMiner.classes.Settings import FollowersOrder, Priority, Settings, StreamerSource
 from TwitchChannelPointsMiner.classes.StreamerSelector import (
     StreamerSelector,
     PrioritySelector,
@@ -284,8 +284,8 @@ class TwitchChannelPointsMiner:
             def normalize_login(name: str) -> str:
                 return name.lower().strip().replace(" ", "")
 
-            streamers_name: list = []
-            streamers_dict: dict = {}
+            streamers_pre_loaded: list[tuple[str, StreamerSource]] = []
+            streamers_dict: dict[str, str | Streamer] = {}
 
             for streamer in streamers_input:
                 username = (
@@ -294,7 +294,7 @@ class TwitchChannelPointsMiner:
                     else normalize_login(str(streamer))
                 )
                 if username not in blacklist_input:
-                    streamers_name.append(username)
+                    streamers_pre_loaded.append((username, StreamerSource.Streamers))
                     streamers_dict[username] = streamer
 
             if followers is True:
@@ -309,22 +309,23 @@ class TwitchChannelPointsMiner:
                         and normalize_login(username) not in blacklist_input
                     ):
                         norm = normalize_login(username)
-                        streamers_name.append(norm)
+                        streamers_pre_loaded.append((norm, StreamerSource.Followers))
                         streamers_dict[norm] = norm
 
             logger.info(
-                f"Loading data for {len(streamers_name)} streamers. Please wait...",
+                f"Loading data for {len(streamers_pre_loaded)} streamers. Please wait...",
                 extra={"emoji": ":nerd_face:"},
             )
-            load_workers = max(1, min(10, len(streamers_name))) if streamers_name else 0
+            load_workers = max(1, min(10, len(streamers_pre_loaded))) if streamers_pre_loaded else 0
 
-            def build_streamer(username: str):
+            def build_streamer(username: str, source: StreamerSource):
                 streamer_obj = streamers_dict[username]
-                streamer = (
+                streamer: Streamer = (
                     streamer_obj
-                    if isinstance(streamer_obj, Streamer) is True
+                    if isinstance(streamer_obj, Streamer)
                     else Streamer(username)
                 )
+                streamer.source = source
                 streamer.channel_id = self.twitch.get_channel_id(username)
                 streamer.settings = set_default_settings(
                     streamer.settings, Settings.streamer_settings
@@ -340,16 +341,16 @@ class TwitchChannelPointsMiner:
                     )
                 return streamer
 
-            streamers_loaded: list[None | Streamer] = [None] * len(streamers_name)
-            if streamers_name:
+            streamers_loaded: list[None | Streamer] = [None] * len(streamers_pre_loaded)
+            if streamers_pre_loaded:
                 with ThreadPoolExecutor(max_workers=load_workers or 1) as executor:
                     futures = {
-                        executor.submit(build_streamer, username): index
-                        for index, username in enumerate(streamers_name)
+                        executor.submit(build_streamer, username, source): index
+                        for index, (username, source) in enumerate(streamers_pre_loaded)
                     }
                     for future in as_completed(futures):
                         index = futures[future]
-                        username = streamers_name[index]
+                        username = streamers_pre_loaded[index]
                         try:
                             streamers_loaded[index] = future.result()
                         except StreamerDoesNotExistException:

--- a/TwitchChannelPointsMiner/classes/Settings.py
+++ b/TwitchChannelPointsMiner/classes/Settings.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import Enum, auto, StrEnum
 
 
 class Priority(Enum):
@@ -10,16 +10,12 @@ class Priority(Enum):
     POINTS_DESCENDING = auto()
 
 
-class PriorityGroup:
-    """Priority(s) to be applied over a given list of streamers."""
-
-    def __init__(
-        self, priority: list[Priority], streamers: list[str] | None = None
-    ) -> None:
-        self.priority = priority
-        """The priority(s) of the streamers(s) to select."""
-        self.streamers = streamers
-        """The streamers in the group. Applies to all streamers if None."""
+class StreamerSource(StrEnum):
+    """ Represents the source of a Streamer. """
+    Streamers = "streamers"
+    """ The streamer came from the streamers list """
+    Followers = "followers"
+    """ The streamer came from the followers list """
 
 
 class FollowersOrder(Enum):

--- a/TwitchChannelPointsMiner/classes/StreamerSelector.py
+++ b/TwitchChannelPointsMiner/classes/StreamerSelector.py
@@ -1,9 +1,9 @@
 import abc
 import logging
 import time
-from typing import Protocol, Sequence
+from typing import Protocol, Sequence, Callable
 
-from TwitchChannelPointsMiner.classes.Settings import Priority
+from TwitchChannelPointsMiner.classes.Settings import Priority, StreamerSource
 from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer
 from TwitchChannelPointsMiner.utils.LimitedSet import LimitedSet
 
@@ -57,12 +57,12 @@ def priority_streak(streamers: Sequence[Streamer], max_amount: int) -> list[str]
         if len(result) >= max_amount:
             break
         if (
-            streamer.settings.watch_streak is True
-            and streamer.stream.watch_streak_missing is True
-            and (
+                streamer.settings.watch_streak is True
+                and streamer.stream.watch_streak_missing is True
+                and (
                 streamer.offline_at == 0
                 or ((time.time() - streamer.offline_at) // 60) > 30
-            )
+        )
         ):
             result.append(streamer.channel_id)
     return result
@@ -107,10 +107,10 @@ class PrioritySelector(StreamerSelector):
 
     def __init__(
         self,
-        priorities: list[Priority],
+        priorities: list[Priority] | None = None,
         priority_function_overrides: dict[Priority, PriorityFunction] | None = None,
     ):
-        self.priorities = priorities
+        self.priorities = priorities if priorities is not None else [Priority.STREAK, Priority.DROPS, Priority.ORDER]
         if priority_function_overrides is not None:
             self.priority_functions = {
                 priority: priority_function_overrides.get(
@@ -143,24 +143,105 @@ class PrioritySelector(StreamerSelector):
         return list(selected)[:max_amount]
 
 
-class PriorityGroupSelector(StreamerSelector):
-    """Selects streamers based on the given PriorityGroup."""
+def all_filter(streamers: Sequence[Streamer]) -> Sequence[Streamer]:
+    """
+    Filter that just returns the original sequence.
 
-    def __init__(self, streamers: list[str] | None, selector: PrioritySelector) -> None:
+    :param streamers: The list of streamers to filter.
+    :return: The filtered list.
+    """
+    return streamers
+
+
+def in_list_filter(filter_streamers: list[str]) -> Callable[[Sequence[Streamer]], Sequence[Streamer]]:
+    """
+    Returns a filter function that filters out any streamers that aren't in the given list (based on usernames).
+
+    :param filter_streamers: The usernames of Streamers to keep.
+    :return: The filter function.
+    """
+
+    def sub_filter(streamers: Sequence[Streamer]) -> Sequence[Streamer]:
+        streamers_by_usernames = {streamer.username: streamer for streamer in streamers}
+        return [
+            streamers_by_usernames[streamer_username]
+            for streamer_username in filter_streamers
+            if streamer_username in streamers_by_usernames
+        ]
+
+    return sub_filter
+
+
+def from_source_filter(filter_source: StreamerSource) -> Callable[[Sequence[Streamer]], Sequence[Streamer]]:
+    """
+    Returns a filter function that filters out any streamers that aren't sourced in the given way.
+
+    :param filter_source: The source of Streamers to keep.
+    :return: The filter function.
+    """
+    return lambda streamers: [
+        streamer
+        for streamer in streamers
+        if streamer.source == filter_source
+    ]
+
+
+def arbitrary_filter(filter_function: Callable[[Streamer], bool]) -> Callable[[Sequence[Streamer]], Sequence[Streamer]]:
+    """
+    Filters out any streamers that don't return `True` for the given function.
+
+    :param filter_function: The function to use when filtering, should return `True` to keep the Streamer.
+    :return: The filter function.
+    """
+    return lambda streamers: [
+        streamer
+        for streamer in streamers
+        if filter_function(streamer)
+    ]
+
+
+class PriorityGroupSelector(StreamerSelector):
+    """Selects streamers based on the given streamers filter."""
+
+    def __init__(
+        self, streamers: list[str] | StreamerSource | Callable[[Streamer], bool] | None, selector: PrioritySelector
+    ) -> None:
         self.streamers = streamers
+        """
+        If `list[str]` selects from only those streamers with the matching usernames.
+        
+        If `StreamerSource` selects from only streamers sourced in the given way.
+        
+        If `Callable` selects from only those streamers that, when passed, return `True`.
+        
+        If `None` selects from all streamers. 
+        """
         self.selector = selector
+        """ The `PrioritySelector` to use for the given streamers. """
+
+        # Cache filter function now to avoid doing isinstance every time
+        self._filter: Callable[[Sequence[Streamer]], Sequence[Streamer]]
+        if self.streamers is None:
+            # Use all streamers if None
+            self._filter = all_filter
+        elif isinstance(self.streamers, StreamerSource):
+            # Filter streamers to only those from the given source
+            self._filter = from_source_filter(self.streamers)
+        elif isinstance(self.streamers, Callable):
+            # Filter streamers by filter function
+            self._filter = arbitrary_filter(self.streamers)
+        elif isinstance(self.streamers, list):
+            if len(self.streamers) > 0:
+                # Filter out streamers that aren't in the list
+                self._filter = in_list_filter(self.streamers)
+            else:
+                # Use all streamers if list is empty
+                self._filter = all_filter
+        else:
+            raise TypeError("Streamers must be one of list[str], StreamerSource, Callable, or None")
 
     def select(self, streamers: Sequence[Streamer], max_amount: int) -> list[str]:
-        streamers_by_ids = {streamer.channel_id: streamer for streamer in streamers}
-        if self.streamers is None or len(self.streamers) == 0:
-            sub_streamers = streamers
-        else:
-            group_streamers = self.streamers
-            sub_streamers = [
-                streamers_by_ids[streamer_id]
-                for streamer_id in group_streamers
-                if streamer_id in streamers_by_ids
-            ]
+        sub_streamers = self._filter(streamers)
         selection = self.selector.select(sub_streamers, max_amount)
         return selection[:max_amount]
 
@@ -197,7 +278,8 @@ def priority_streak_by_earliest_stream_created_at(
     :param max_amount: The maximum amount of streamers to select.
     :return: The selected streamer ids.
     """
-    ordered = sorted(streamers,
+    ordered = sorted(
+        streamers,
         key=lambda streamer: (
             streamer.stream.created_at.timestamp()
             if streamer.stream.created_at is not None

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -8,7 +8,7 @@ from threading import Lock
 from TwitchChannelPointsMiner.classes.Chat import ChatPresence, ThreadChat
 from TwitchChannelPointsMiner.classes.entities.Bet import BetSettings, DelayMode
 from TwitchChannelPointsMiner.classes.entities.Stream import Stream
-from TwitchChannelPointsMiner.classes.Settings import Events, Settings
+from TwitchChannelPointsMiner.classes.Settings import Events, Settings, StreamerSource
 from TwitchChannelPointsMiner.classes.gql import Properties
 from TwitchChannelPointsMiner.constants import URL
 from TwitchChannelPointsMiner.utils import millify
@@ -74,6 +74,7 @@ class Streamer(object):
         "username",
         "channel_id",
         "settings",
+        "source",
         "is_online",
         "stream_up",
         "online_at",
@@ -105,10 +106,12 @@ class Streamer(object):
         offline_at: float | None = None,
         active_multipliers: list[Properties.Multiplier] | None = None,
         settings: StreamerSettings | None = None,
+        source: StreamerSource = StreamerSource.Streamers,
     ):
         self.username: str = username.lower().strip()
         self.channel_id: str = channel_id if channel_id is not None else ""
         self.settings = settings
+        self.source = source
         self.is_online = False
         self.stream_up = 0
         self.online_at = online_at if online_at is not None else 0.0

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -118,8 +118,11 @@ prioritises streamers in the reverse of the order they are defined.
 
 ##### `PriorityGroupSelector`
 
-This selector takes a `list[str]` (Twitch usernames) and a `PrioritySelector`. It will select only streamers with the
-given usernames using the given selector. For example:
+This selector applies a given `PrioritySelector` to a particular group of streamers. The streamers can be configured in
+several different ways:
+
+It can take a `list[str]` (Twitch usernames). It will select only streamers with the given usernames using the given
+selector. For example:
 
 ```python3
 PriorityGroupSelector(
@@ -132,7 +135,59 @@ PriorityGroupSelector(
 
 This will attempt to select only `streamer1` or `streamer2` in that order.
 
-You can also not specify `streamers` in which case it will consider all streamers.
+You can also not specify `streamers` in which case it will consider all streamers:
+
+```python3
+PriorityGroupSelector(
+    selector=PrioritySelector(
+        priorities=[Priority.Order]
+    )
+)
+```
+
+The same thing happens if you supply `streamers` with an empty list (`[]`):
+
+```python3
+PriorityGroupSelector(
+    streamers=[],
+    selector=PrioritySelector(
+        priorities=[Priority.Order]
+    )
+)
+```
+
+You can also specify a `StreamerSource` to consider only streamers that were sourced in the given way:
+
+```python3
+PriorityGroupSelector(
+    streamers=StreamerSource.Streamers,
+    selector=PrioritySelector(
+        priorities=[Priority.Order]
+    )
+)
+```
+
+`StreamerSource.Streamers` means all streamers specified in your `streamers` list, not including followers,
+see [here](#streamers) for details. `StreamerSource.Followers` means all streamers that your account follows, see
+[here](#followers) for details.
+
+You may also specify an arbitrary filter function:
+
+> [!IMPORTANT]
+> Please test that your filter function works the way you expect. We can't help debug code that's not part of the
+> project.
+
+```python3
+PriorityGroupSelector(
+    streamers=lambda streamer: streamer.channel_points < 5000,
+    selector=PrioritySelector(
+        priorities=[Priority.Order]
+    )
+)
+```
+
+In this case we've specified a function that takes a `Streamer` and returns `True` if they have fewer than 5000 channel
+points. You can replace that function with anything that takes a `Streamer` and returns a `bool`.
 
 ##### `NestedSelector`
 

--- a/tests/classes/test_streamer_selector.py
+++ b/tests/classes/test_streamer_selector.py
@@ -1,10 +1,11 @@
 import datetime
 import time
+from typing import Sequence, Callable
 from unittest.mock import MagicMock
 
 import pytest
 
-from TwitchChannelPointsMiner.classes.Settings import Priority, PriorityGroup
+from TwitchChannelPointsMiner.classes.Settings import Priority, StreamerSource
 from TwitchChannelPointsMiner.classes.StreamerSelector import (
     PriorityGroupSelector,
     PrioritySelector,
@@ -603,11 +604,11 @@ def test_priority_subscribed(
     assert streamer_ids == expected_ids
 
 
-def priority_selects_none(streamers: list[Streamer], max_amount: int) -> list[str]:
+def priority_selects_none(streamers: Sequence[Streamer], max_amount: int) -> list[str]:
     return []
 
 
-def priority_selects_first(streamers: list[Streamer], max_amount: int) -> list[str]:
+def priority_selects_first(streamers: Sequence[Streamer], max_amount: int) -> list[str]:
     return [streamers[0].channel_id]
 
 
@@ -700,46 +701,39 @@ class TestPrioritySelector:
 
 
 class TestPriorityGroupSelector:
-    basic_priorities = [Priority.STREAK, Priority.SUBSCRIBED, Priority.ORDER]
-
-    streamer_a = Streamer("1", "a")
-    streamer_b = Streamer("2", "b")
-    streamer_c = Streamer("3", "c")
+    streamer_a = Streamer("1", "a", source=StreamerSource.Streamers)
+    streamer_b = Streamer("2", "b", source=StreamerSource.Followers)
+    streamer_c = Streamer("3", "c", source=StreamerSource.Streamers)
 
     select_from_all_data = [
-        [[], 0, PriorityGroup([]), [], []],
-        [[], 1, PriorityGroup([]), [], []],
-        [[], 2, PriorityGroup([]), [], []],
-        [[], 0, PriorityGroup(basic_priorities), [], []],
-        [[], 1, PriorityGroup(basic_priorities), [], []],
-        [[], 2, PriorityGroup(basic_priorities), [], []],
+        [[], 0, [], [], []],
+        [[], 1, [], [], []],
+        [[], 2, [], [], []],
         [
             [streamer_a],
             0,
-            PriorityGroup(
-                basic_priorities,
-            ),
+            [],
             [streamer_a],
             [],
         ],
         [
             [streamer_a],
             1,
-            PriorityGroup(basic_priorities),
+            [],
             [streamer_a],
             ["a"],
         ],
         [
             [streamer_a],
             1,
-            PriorityGroup(basic_priorities),
+            [],
             [streamer_a],
             [],
         ],
         [
             [streamer_a, streamer_b],
             2,
-            PriorityGroup(basic_priorities),
+            [],
             [streamer_a, streamer_b],
             ["a", "b"],
         ],
@@ -747,42 +741,142 @@ class TestPriorityGroupSelector:
         [
             [streamer_a, streamer_b],
             2,
-            PriorityGroup(basic_priorities, ["a"]),
+            ["1"],
             [streamer_a],
             ["a"],
         ],
         [
             [streamer_a, streamer_b, streamer_c],
             2,
-            PriorityGroup(basic_priorities, ["a", "b", "c"]),
+            ["1", "2", "3"],
             [streamer_a, streamer_b, streamer_c],
             ["a", "b"],
         ],
         [
             [streamer_a, streamer_b, streamer_c],
             2,
-            PriorityGroup(basic_priorities, ["c"]),
+            ["3"],
             [streamer_c],
             ["c"],
         ],
         [
             [streamer_a, streamer_b, streamer_c],
             2,
-            PriorityGroup(basic_priorities, ["b", "c"]),
+            ["2", "3"],
             [streamer_b, streamer_c],
             ["b", "c"],
+        ],
+        # StreamerSource.Streamers
+        [
+            [streamer_a, streamer_b, streamer_c],
+            0,
+            StreamerSource.Streamers,
+            [streamer_a, streamer_c],
+            []
+        ],
+        [
+            [streamer_a, streamer_b, streamer_c],
+            1,
+            StreamerSource.Streamers,
+            [streamer_a, streamer_c],
+            ["a"]
+        ],
+        [
+            [streamer_a, streamer_b, streamer_c],
+            2,
+            StreamerSource.Streamers,
+            [streamer_a, streamer_c],
+            ["a", "c"]
+        ],
+        [
+            [streamer_a, streamer_b, streamer_c],
+            3,
+            StreamerSource.Streamers,
+            [streamer_a, streamer_c],
+            ["a", "c"]
+        ],
+        # StreamerSource.Followers
+        [
+            [streamer_a, streamer_b, streamer_c],
+            0,
+            StreamerSource.Followers,
+            [streamer_b],
+            []
+        ],
+        [
+            [streamer_a, streamer_b, streamer_c],
+            1,
+            StreamerSource.Followers,
+            [streamer_b],
+            ["b"]
+        ],
+        [
+            [streamer_a, streamer_b, streamer_c],
+            2,
+            StreamerSource.Followers,
+            [streamer_b],
+            ["b"]
+        ],
+        [
+            [streamer_a, streamer_b, streamer_c],
+            3,
+            StreamerSource.Followers,
+            [streamer_b],
+            ["b"]
+        ],
+        # Arbitrary Callable Filter
+        [
+            [streamer_a, streamer_b, streamer_c],
+            0,
+            lambda s: s.channel_id in [],
+            [],
+            []
+        ],
+        [
+            [streamer_a, streamer_b, streamer_c],
+            1,
+            lambda s: s.channel_id in [],
+            [],
+            []
+        ],
+        [
+            [streamer_a, streamer_b, streamer_c],
+            1,
+            lambda s: s.channel_id in ["d"],
+            [],
+            []
+        ],
+        [
+            [streamer_a, streamer_b, streamer_c],
+            2,
+            lambda s: s.channel_id in ["a", "b", "c"],
+            [streamer_a, streamer_b, streamer_c],
+            ["a", "b"],
+        ],        [
+            [streamer_a, streamer_b, streamer_c],
+            2,
+            lambda s: s.channel_id in ["b", "c"],
+            [streamer_b, streamer_c],
+            ["b", "c"],
+        ],
+        [
+            [streamer_a, streamer_b, streamer_c],
+            3,
+            lambda s: s.channel_id in ["a", "c"],
+            [streamer_a, streamer_c],
+            ["a", "c"],
         ],
     ]
 
     @pytest.mark.parametrize(
-        "streamers,max_amount,group,expected_filtered_ids,expected_ids",
+        "streamers,max_amount,streamer_filter,expected_filtered_ids,expected_ids",
         select_from_all_data,
     )
     def test_select(
         self,
         streamers: list[Streamer],
         max_amount: int,
-        group: PriorityGroup,
+        streamer_filter: list[str] | StreamerSource | Callable[[Streamer], bool] | None,
         expected_filtered_ids: list[str],
         expected_ids: list[str],
     ):
@@ -793,7 +887,7 @@ class TestPriorityGroupSelector:
 
         # Test
 
-        streamer_ids = PriorityGroupSelector(group.streamers, selector).select(
+        streamer_ids = PriorityGroupSelector(streamer_filter, selector).select(
             streamers, max_amount
         )
 
@@ -809,7 +903,7 @@ class SelectAmount(StreamerSelector):
     def __init__(self, amount: int):
         self.amount = amount
 
-    def select(self, streamers: list[Streamer], max_amount: int) -> list[str]:
+    def select(self, streamers: Sequence[Streamer], max_amount: int) -> list[str]:
         return [
             streamer.channel_id
             for streamer in streamers[: min(self.amount, max_amount)]


### PR DESCRIPTION
# Description

Extends `PriorityGroupSelector` to allow filtering streamers based on their source (streamers list/followers list) or a provided filter function.

Also fixes an issue when supplying it a `list[str]` where the user needed to use the channel id rather than the channel username. Filtering based on the username was always the intended functionality.

Removes unused `PriorityGroup` type.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added new test cases to cover new functionality, then tan all tests. Ran a live test for a few hours with the new options.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt