### PR TITLE
Adds more guards to `Hermes.Pool` to avoid a potential deadlock.

### DIFF
--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -566,11 +566,12 @@ class TwitchChannelPointsMiner:
                     streamer.irc_chat.join()
 
         self.running = self.twitch.running = False
-        if self.ws_pool is not None:
-            self.ws_pool.end()
 
         for task in self.background_tasks:
             task.join()
+
+        if self.ws_pool is not None:
+            self.ws_pool.end()
 
         # Check if all the mutex are unlocked.
         # Prevent breaks of .json file

--- a/TwitchChannelPointsMiner/classes/websocket/hermes/Pool.py
+++ b/TwitchChannelPointsMiner/classes/websocket/hermes/Pool.py
@@ -133,6 +133,9 @@ class HermesWebSocketPool(WebSocketPool, HermesWebSocketListener):
         Reconnects the given client.
         :param client: The client to reconnect.
         """
+        # Don't reconnect if the pool is closed
+        if self.force_close:
+            return
         with self.__lock:
             # First ensure that the client is closed as a catch-all for dangling clients
             client.close()
@@ -238,6 +241,9 @@ class HermesWebSocketPool(WebSocketPool, HermesWebSocketListener):
         :param client: The client that's errored.
         :param error: The error Exception.
         """
+        # Ignore errors if the pool is closed
+        if self.force_close:
+            return
         # Ignore the stack trace for socket closures, we'll get additional info in the on_close
         is_closed_error = isinstance(error, WebSocketConnectionClosedException)
         if is_closed_error:
@@ -262,6 +268,9 @@ class HermesWebSocketPool(WebSocketPool, HermesWebSocketListener):
             self.clients.clear()
 
     def check_stale_connections(self):
+        # Don't check if the pool is closed
+        if self.force_close:
+            return
         logger.debug(f"Checking stale connections")
         for client_index in range(len(self.clients)):
             client = self.clients[client_index]


### PR DESCRIPTION
# Description

Fixes #10 

Addresses an issue where the miner would get stuck trying to end when using the `Hermes` WebSocket API.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally. Currently waiting on feedback from the reporter of the original issue.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt