### PR TITLE
Logging Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ the [CONTRIBUTING.md](docs/CONTRIBUTING.md) file.
     - User mentions in chat
 - Analytics site showing charts with information about the miner's performance
 - Fully configurable and extensible (see the [example](example.py))
+- Optional log anonymiser and secret redactor
 
 ## Limits
 

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -547,6 +547,8 @@ class TwitchChannelPointsMiner:
                         f"Background task(s) {list(map(lambda task: task.name, filter(not_is_alive, self.background_tasks)))} have stopped working. Stopping application."
                     )
                     break
+        except Exception as e:
+            logger.exception(f"Error in main miner loop", exc_info=e)
         finally:
             self.end()
 

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -350,17 +350,18 @@ class TwitchChannelPointsMiner:
                     }
                     for future in as_completed(futures):
                         index = futures[future]
-                        username = streamers_pre_loaded[index]
+                        username, _ = streamers_pre_loaded[index]
                         try:
                             streamers_loaded[index] = future.result()
                         except StreamerDoesNotExistException:
                             logger.info(
-                                f"Streamer {username} does not exist",
+                                f"Streamer {Settings.logger.anonymiser.username(username)} does not exist",
                                 extra={"emoji": ":cry:"},
                             )
                         except Exception:
                             logger.error(
-                                f"Failed to load streamer {username}", exc_info=True
+                                f"Failed to load streamer {Settings.logger.anonymiser.username(username)}",
+                                exc_info=True
                             )
 
             self.streamers = [
@@ -594,8 +595,9 @@ class TwitchChannelPointsMiner:
             f"Ending session: '{self.session_id}'", extra={"emoji": ":stop_sign:"}
         )
         if self.logs_file is not None:
+            redacted_logs_file = self.logs_file.replace(self.username, Settings.logger.anonymiser.username(self.username))
             logger.info(
-                f"Logs file: {self.logs_file}", extra={"emoji": ":page_facing_up:"}
+                f"Logs file: {redacted_logs_file}", extra={"emoji": ":page_facing_up:"}
             )
         logger.info(
             f"Duration {datetime.now() - self.start_datetime}",

--- a/TwitchChannelPointsMiner/classes/AnalyticsServer.py
+++ b/TwitchChannelPointsMiner/classes/AnalyticsServer.py
@@ -102,16 +102,20 @@ def filter_datas(start_date, end_date, datas):
     return datas
 
 
-def read_json(streamer, return_response=True):
+def read_json(streamer: str, return_response=True):
     start_date = request.args.get("startDate", type=str)
     end_date = request.args.get("endDate", type=str)
 
     path = Settings.analytics_path
-    streamer = streamer if streamer.endswith(".json") else f"{streamer}.json"
+    if streamer.endswith(".json"):
+        streamer_username = streamer[:-5].strip()
+    else:
+        streamer_username = streamer
+        streamer = f"{streamer}.json"
 
     # Check if the file exists before attempting to read it
     if not os.path.exists(os.path.join(path, streamer)):
-        error_message = f"File '{streamer}' not found."
+        error_message = f"File '{Settings.logger.anonymiser.username(streamer_username)}' not found."
         logger.error(error_message)
         if return_response:
             return Response(json.dumps({"error": error_message}), status=404, mimetype="application/json")
@@ -122,7 +126,7 @@ def read_json(streamer, return_response=True):
         with open(os.path.join(path, streamer), 'r') as file:
             data = json.load(file)
     except json.JSONDecodeError as e:
-        error_message = f"Error decoding JSON in file '{streamer}': {str(e)}"
+        error_message = f"Error decoding JSON in file '{Settings.logger.anonymiser.username(streamer_username)}': {str(e)}"
         logger.error(error_message)
         if return_response:
             return Response(json.dumps({"error": error_message}), status=500, mimetype="application/json")

--- a/TwitchChannelPointsMiner/classes/Anonymiser.py
+++ b/TwitchChannelPointsMiner/classes/Anonymiser.py
@@ -1,19 +1,53 @@
 import abc
+import io
+import os
+import pathlib
 import random
+import traceback
 from threading import Lock
-from typing import Callable
+from types import TracebackType
+from typing import Callable, Literal, TypeAlias, Any
 
 from TwitchChannelPointsMiner.classes.entities.PubsubTopic import PubsubTopic
 from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer
 from TwitchChannelPointsMiner.utils.Utils import generate_random_uuid
 
+# To avoid import errors from traceback
+_SysExcInfoType: TypeAlias = tuple[type[BaseException], BaseException, TracebackType | None] | tuple[None, None, None]
+
 
 class Anonymiser(abc.ABC):
     """ Anonymises various information from the miner. """
 
-    def __init__(self, strict: bool = False):
+    base_path: str | Literal[False]
+    """The beginning part of a filepath to redact. If False, filepaths will not be anonymised."""
+
+    def __init__(
+        self,
+        channel_ids=True,
+        usernames=True,
+        channel_points=True,
+        strict: bool = False,
+        base_path: str | bool = True
+    ):
+        """
+        If `base_path` is True then the expected base directory of this module (the great-grandparent of this file) will
+         be used.
+        """
+        self.anonymise_channel_ids = channel_ids
+        """If True, channel ids will be anonymised."""
+        self.anonymise_usernames = usernames
+        """If True, usernames will be anonymised."""
+        self.anonymise_channel_points = channel_points
+        """If True, filepaths will be anonymised. This includes filepaths in Exception logs."""
         self.strict = strict
         """If True, the Anonymiser will stop the logging of external data (such as HTTP responses). """
+        if base_path is False:
+            self.base_path = False
+        elif base_path is True:
+            self.base_path = str(pathlib.Path(__file__).parent.parent.parent.resolve())
+        else:
+            self.base_path = base_path
 
     @abc.abstractmethod
     def channel_id(self, channel_id: str) -> str:
@@ -84,12 +118,88 @@ class Anonymiser(abc.ABC):
         topic, _id = topic_str.split(".")
         return f"{topic}.{self.channel_id(_id)}"
 
+    def filepath(self, filepath: str) -> str:
+        """
+        Redacts the path from the given `filepath` leaving just the filename. Removes either the `base_path` or
+        everything before the final separator, if one exists. For example:
+
+        if `self.base_path` = "/home/username/miner"
+
+        and `filename` = "/home/username/miner/module_1/module_2/some_python_file.py"
+
+        then the result path = "[PATH REDACTED]/module_1/module_2/some_python_file.py"
+
+        The main benefit here being that your local username (in this example it's just "username") is redacted.
+
+        However:
+
+        if `filename` = "/home/username/.local/lib/python3.12/site-packages/package/some_python_file.py"
+
+        then the result path = "[PATH REDACTED]/some_python_file.py"
+
+        This is to avoid situations where there might be identifying information in the filepath for a python module
+        that the application is using from elsewhere on your system.
+
+        :param filepath: The filename from which to redact the path.
+        :return: The redacted filename.
+        """
+        if self.base_path is False:
+            return filepath
+        if filepath.startswith(self.base_path):
+            index = filepath.index(self.base_path) + len(self.base_path)
+            return f"[PATH REDACTED]{filepath[index:]}"
+        else:
+            try:
+                return f"[PATH REDACTED]{filepath[filepath.rindex(os.path.sep):]}"
+            except ValueError:
+                return filepath
+
+    def format_exception(self, ei: _SysExcInfoType) -> str:
+        """
+        Formats Exceptions the same as `logging.Formatter` but redacts all filepaths in the exception's stack. This
+        applies not just to the current exception but to all chained exceptions recursively (i.e. the Exceptions'
+        `__cause__` and `__context__`).
+
+        :param ei: The Exception to format.
+        :return: The anonymised exception string.
+        """
+        # TracebackException can and does explicitly handle None here so type as Any to avoid errors
+        exception_type: Any
+        exception: Any
+        exception_type, exception, exception_traceback = ei
+        traceback_exception = traceback.TracebackException(
+            exception_type,
+            exception,
+            exception_traceback,
+            limit=None,
+            compact=True
+        )
+        if self.base_path is not False:
+            # Redact paths from the current exception and the cause/context iteratively
+            current_traceback = traceback_exception
+            while current_traceback is not None:
+                for frame_summary in current_traceback.stack:
+                    frame_summary.filename = self.filepath(frame_summary.filename)
+                if current_traceback.__cause__ is not None:
+                    current_traceback = current_traceback.__cause__
+                elif current_traceback.__context__ is not None:
+                    current_traceback = current_traceback.__context__
+                else:
+                    current_traceback = None
+
+        with io.StringIO() as sio:
+            traceback_exception.print(file=sio)
+            result = sio.getvalue()
+            if result[-1:] == "\n":
+                result = result[:-1]
+            return result
+
 
 class Deanonymiser(Anonymiser):
     """ Anonymiser that doesn't change anything. """
 
     def __init__(self, strict: bool = False):
-        super().__init__(strict)
+        super().__init__(channel_ids=False, usernames=False, channel_points=False, strict=strict, base_path=False)
 
     def channel_id(self, channel_id: str) -> str:
         return channel_id
@@ -105,6 +215,9 @@ class Deanonymiser(Anonymiser):
 
     def hermes_subscription_id(self, _id: str) -> str:
         return _id
+
+    def filepath(self, filepath: str) -> str:
+        return filepath
 
 
 class RandomSource:
@@ -126,23 +239,39 @@ class RandomAnonymiser(Anonymiser):
 
     def __init__(
         self,
+        channel_ids=True,
+        usernames=True,
+        channel_points=True,
         strict: bool = True,
+        base_path: str | bool = True,
         random_source: RandomSource = RandomSource()
     ):
-        super().__init__(strict)
+        super().__init__(channel_ids, usernames, channel_points, strict, base_path)
         self.random_source = random_source
 
     def channel_id(self, channel_id: str) -> str:
-        return str(self.random_source.random_int(1, 100))
+        if self.anonymise_channel_ids:
+            return str(self.random_source.random_int(1, 100))
+        else:
+            return channel_id
 
     def username(self, username: str) -> str:
-        return f"Streamer {self.random_source.random_int(1, 100)}"
+        if self.anonymise_usernames:
+            return f"Streamer {self.random_source.random_int(1, 100)}"
+        else:
+            return username
 
     def channel_points(self, streamer: Streamer) -> int:
-        return self.random_source.random_int(0, 1_000_000)
+        if self.anonymise_channel_points:
+            return self.random_source.random_int(0, 1_000_000)
+        else:
+            return streamer.channel_points
 
     def hermes_subscription_id(self, _id: str) -> str:
-        return f"Hermes Subscription {self.random_source.random_uuid()}"
+        if self.anonymise_channel_ids:
+            return f"Hermes Subscription {self.random_source.random_uuid()}"
+        else:
+            return _id
 
 
 class IdStore[ValueType](abc.ABC):
@@ -203,12 +332,16 @@ class ConsistentAnonymiser(Anonymiser):
 
     def __init__(
         self,
+        channel_ids=True,
+        usernames=True,
+        channel_points=True,
         strict: bool = True,
+        base_path: str | bool = True,
         random_points_min: int = 100,
         random_points_max: int = 1_000_000,
-        random_source: RandomSource = RandomSource()
+        random_source: RandomSource = RandomSource(),
     ):
-        super().__init__(strict)
+        super().__init__(channel_ids, usernames, channel_points, strict, base_path)
         self._random_points_min = random_points_min
         self._random_points_max = random_points_max
         self._random_source = random_source
@@ -221,15 +354,21 @@ class ConsistentAnonymiser(Anonymiser):
         self._channel_points_lock = Lock()
 
     def channel_id(self, channel_id: str) -> str:
+        if not self.anonymise_channel_ids:
+            return channel_id
         # An empty id means the channel id hasn't been initialised so just return it as is
         if channel_id == "":
             return ""
         return str(self._streamer_ids.id(channel_id))
 
     def username(self, username: str) -> str:
+        if not self.anonymise_usernames:
+            return username
         return f"Streamer{self._streamer_names.id(username)}"
 
     def channel_points(self, streamer: Streamer) -> int:
+        if not self.anonymise_channel_points:
+            return streamer.channel_points
         with self._channel_points_lock:
             if streamer.username not in self._streamer_channel_points:
                 state = ConsistentAnonymiser.ChannelPointsState(
@@ -245,4 +384,7 @@ class ConsistentAnonymiser(Anonymiser):
         return state.fake_points
 
     def hermes_subscription_id(self, subscription_id: str) -> str:
-        return f"Hermes Subscription {self._hermes_subscription_ids.id(subscription_id)}"
+        if self.anonymise_channel_ids:
+            return f"Hermes Subscription {self._hermes_subscription_ids.id(subscription_id)}"
+        else:
+            return subscription_id

--- a/TwitchChannelPointsMiner/classes/Anonymiser.py
+++ b/TwitchChannelPointsMiner/classes/Anonymiser.py
@@ -1,0 +1,229 @@
+import abc
+import random
+from threading import Lock
+from typing import Callable
+
+from TwitchChannelPointsMiner.classes.entities.PubsubTopic import PubsubTopic
+from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer
+from TwitchChannelPointsMiner.utils.Utils import generate_random_uuid
+
+
+class Anonymiser(abc.ABC):
+    """ Anonymises various information from the miner. """
+
+    @abc.abstractmethod
+    def channel_id(self, channel_id: str) -> str:
+        """
+        Gets a channel id for the given Streamer channel id.
+
+        :param channel_id: The id of the Streamer.
+        :return: The id.
+        """
+        pass
+
+    @abc.abstractmethod
+    def username(self, username: str) -> str:
+        """
+        Gets a username for the Streamer with the given username.
+
+        :param username: The username of the Streamer.
+        :return: The username.
+        """
+        pass
+
+    @abc.abstractmethod
+    def channel_points(self, streamer: Streamer) -> int:
+        """
+        Gets the channel points for the given Streamer.
+
+        :param streamer: The Streamer.
+        :return: The channel points.
+        """
+        pass
+
+    @abc.abstractmethod
+    def hermes_subscription_id(self, _id: str) -> str:
+        """
+        Gets a Hermes topic subscription id.
+
+        :param _id: The id to anonymise.
+        :return: The anonymised id.
+        """
+        pass
+
+    def streamer_username(self, streamer: Streamer) -> str:
+        """
+        Gets a name for the given Streamer.
+
+        :param streamer: The Streamer.
+        :return: The name.
+        """
+        return self.username(streamer.username)
+
+    def streamer_channel_id(self, streamer: Streamer) -> str:
+        """
+        Gets a channel id for the given Streamer.
+
+        :param streamer: The Streamer.
+        :return: The id.
+        """
+        return self.channel_id(streamer.channel_id)
+
+    def topic(self, topic: str | PubsubTopic) -> str:
+        """
+        Redacts channel id in the given topic string ("[topic name].[channel id]") or PubsubTopic object.
+
+        :param topic: The topic.
+        :return: The redacted topic string.
+        """
+        topic_str = str(topic)
+        topic, _id = topic_str.split(".")
+        return f"{topic}.{self.channel_id(_id)}"
+
+
+class Deanonymiser(Anonymiser):
+    """ Anonymiser that doesn't change anything. """
+
+    def channel_id(self, channel_id: str) -> str:
+        return channel_id
+
+    def username(self, username: str) -> str:
+        return username
+
+    def channel_points(self, streamer: Streamer) -> int:
+        return streamer.channel_points
+
+    def topic(self, topic: str | PubsubTopic) -> str:
+        return str(topic)
+
+    def hermes_subscription_id(self, _id: str) -> str:
+        return _id
+
+
+class RandomSource:
+    """Utility to allow overriding random behaviour."""
+
+    def __init__(self, random_int=random.randint, random_uuid=generate_random_uuid):
+        self._random_int: Callable[[int, int], int] = random_int
+        self._random_uuid: Callable[[], str] = random_uuid
+
+    def random_int(self, a: int, b: int) -> int:
+        return self._random_int(a, b)
+
+    def random_uuid(self):
+        return self._random_uuid()
+
+
+class RandomAnonymiser(Anonymiser):
+    """ Anonymises various information from the miner in an inconsistent (random) manner. """
+
+    def __init__(self, random_source: RandomSource):
+        self.random_source = random_source
+
+    def channel_id(self, channel_id: str) -> str:
+        return str(self.random_source.random_int(1, 100))
+
+    def username(self, username: str) -> str:
+        return f"Streamer {self.random_source.random_int(1, 100)}"
+
+    def channel_points(self, streamer: Streamer) -> int:
+        return self.random_source.random_int(0, 1_000_000)
+
+    def hermes_subscription_id(self, _id: str) -> str:
+        return f"Hermes Subscription {self.random_source.random_uuid()}"
+
+
+class IdStore[ValueType](abc.ABC):
+    """ Base class to help store a map of keys to ids. """
+
+    def __init__(self):
+        self._ids = dict[str, ValueType]()
+        self._lock = Lock()
+
+    @abc.abstractmethod
+    def _next_id(self) -> ValueType:
+        pass
+
+    def id(self, key: str):
+        """
+        Gets the id for the given key, this will either be the previous id generated for the given key or a new id if
+        this is the first usage.
+
+        :param key: The key for which to get the id.
+        :return: The id generated/retrieved.
+        """
+        with self._lock:
+            if key not in self._ids:
+                self._ids[key] = self._next_id()
+            return self._ids[key]
+
+
+class UUIDStore(IdStore[str]):
+    """Utility top help store a map of keys to random UUIDs."""
+
+    def __init__(self, random_uuid=generate_random_uuid):
+        super().__init__()
+        self.random_uuid = random_uuid
+
+    def _next_id(self) -> str:
+        return self.random_uuid()
+
+
+class IncrementingIdStore(IdStore[int]):
+    """ Utility to help store a map of keys to an incrementing id/index. """
+
+    def __init__(self):
+        super().__init__()
+        self._last_id = 0
+
+    def _next_id(self) -> int:
+        self._last_id += 1
+        return self._last_id
+
+
+class ConsistentAnonymiser(Anonymiser):
+    """ Anonymises various information from the miner in a consistent manner. """
+
+    class ChannelPointsState:
+        def __init__(self, fake_points: int, last_real_points: int):
+            self.fake_points = fake_points
+            self.last_real_points = last_real_points
+
+    def __init__(self, random_points_min: int = 100, random_points_max: int = 1_000_000, random_source=RandomSource()):
+        self._random_points_min = random_points_min
+        self._random_points_max = random_points_max
+        self._random_source = random_source
+
+        self._streamer_ids = IncrementingIdStore()
+        self._streamer_names = IncrementingIdStore()
+        self._streamer_channel_points = dict[str, "ConsistentAnonymiser.ChannelPointsState"]()
+        self._hermes_subscription_ids = UUIDStore(random_uuid=random_source.random_uuid)
+
+        self._channel_points_lock = Lock()
+
+    def channel_id(self, channel_id: str) -> str:
+        # An empty id means the channel id hasn't been initialised so just return it as is
+        if channel_id == "":
+            return ""
+        return str(self._streamer_ids.id(channel_id))
+
+    def username(self, username: str) -> str:
+        return f"Streamer{self._streamer_names.id(username)}"
+
+    def channel_points(self, streamer: Streamer) -> int:
+        with self._channel_points_lock:
+            if streamer.username not in self._streamer_channel_points:
+                state = ConsistentAnonymiser.ChannelPointsState(
+                    fake_points=self._random_source.random_int(self._random_points_min, self._random_points_max),
+                    last_real_points=streamer.channel_points
+                )
+                self._streamer_channel_points[streamer.username] = state
+            else:
+                state = self._streamer_channel_points[streamer.username]
+                delta = streamer.channel_points - state.last_real_points
+                state.fake_points += delta
+                state.last_real_points = streamer.channel_points
+        return state.fake_points
+
+    def hermes_subscription_id(self, subscription_id: str) -> str:
+        return f"Hermes Subscription {self._hermes_subscription_ids.id(subscription_id)}"

--- a/TwitchChannelPointsMiner/classes/Anonymiser.py
+++ b/TwitchChannelPointsMiner/classes/Anonymiser.py
@@ -11,6 +11,10 @@ from TwitchChannelPointsMiner.utils.Utils import generate_random_uuid
 class Anonymiser(abc.ABC):
     """ Anonymises various information from the miner. """
 
+    def __init__(self, strict: bool = False):
+        self.strict = strict
+        """If True, the Anonymiser will stop the logging of external data (such as HTTP responses). """
+
     @abc.abstractmethod
     def channel_id(self, channel_id: str) -> str:
         """
@@ -84,6 +88,9 @@ class Anonymiser(abc.ABC):
 class Deanonymiser(Anonymiser):
     """ Anonymiser that doesn't change anything. """
 
+    def __init__(self, strict: bool = False):
+        super().__init__(strict)
+
     def channel_id(self, channel_id: str) -> str:
         return channel_id
 
@@ -117,7 +124,12 @@ class RandomSource:
 class RandomAnonymiser(Anonymiser):
     """ Anonymises various information from the miner in an inconsistent (random) manner. """
 
-    def __init__(self, random_source: RandomSource):
+    def __init__(
+        self,
+        strict: bool = True,
+        random_source: RandomSource = RandomSource()
+    ):
+        super().__init__(strict)
         self.random_source = random_source
 
     def channel_id(self, channel_id: str) -> str:
@@ -189,7 +201,14 @@ class ConsistentAnonymiser(Anonymiser):
             self.fake_points = fake_points
             self.last_real_points = last_real_points
 
-    def __init__(self, random_points_min: int = 100, random_points_max: int = 1_000_000, random_source=RandomSource()):
+    def __init__(
+        self,
+        strict: bool = True,
+        random_points_min: int = 100,
+        random_points_max: int = 1_000_000,
+        random_source: RandomSource = RandomSource()
+    ):
+        super().__init__(strict)
         self._random_points_min = random_points_min
         self._random_points_max = random_points_max
         self._random_source = random_source

--- a/TwitchChannelPointsMiner/classes/Chat.py
+++ b/TwitchChannelPointsMiner/classes/Chat.py
@@ -72,6 +72,9 @@ class ClientIRC(SingleServerIRCBot):
             nick = event.source.split("!", 1)[0]
             # chan = event.target
 
+            if Settings.logger.anonymiser.strict:
+                msg = "REDACTED"
+
             logger.info(
                 f"{Settings.logger.anonymiser.username(nick)} at {Settings.logger.anonymiser.username(self.channel)} wrote: {msg}",
                 extra={

--- a/TwitchChannelPointsMiner/classes/Chat.py
+++ b/TwitchChannelPointsMiner/classes/Chat.py
@@ -72,8 +72,12 @@ class ClientIRC(SingleServerIRCBot):
             nick = event.source.split("!", 1)[0]
             # chan = event.target
 
-            logger.info(f"{nick} at {self.channel} wrote: {msg}", extra={
-                        "emoji": ":speech_balloon:", "event": Events.CHAT_MENTION})
+            logger.info(
+                f"{Settings.logger.anonymiser.username(nick)} at {Settings.logger.anonymiser.username(self.channel)} wrote: {msg}",
+                extra={
+                    "emoji": ":speech_balloon:", "event": Events.CHAT_MENTION
+                }
+            )
     # """
 
 
@@ -93,13 +97,15 @@ class ThreadChat(Thread):
     def run(self):
         self.chat_irc = ClientIRC(self.username, self.token, self.channel)
         logger.info(
-            f"Join IRC Chat: {self.channel}", extra={"emoji": ":speech_balloon:"}
+            f"Join IRC Chat: {Settings.logger.anonymiser.username(self.channel)}",
+            extra={"emoji": ":speech_balloon:"}
         )
         self.chat_irc.start()
 
     def stop(self):
         if self.chat_irc is not None:
             logger.info(
-                f"Leave IRC Chat: {self.channel}", extra={"emoji": ":speech_balloon:"}
+                f"Leave IRC Chat: {Settings.logger.anonymiser.username(self.channel)}",
+                extra={"emoji": ":speech_balloon:"}
             )
             self.chat_irc.die()

--- a/TwitchChannelPointsMiner/classes/PubSub.py
+++ b/TwitchChannelPointsMiner/classes/PubSub.py
@@ -268,7 +268,8 @@ class PubSubHandler(MessageListener):
                     self.twitch.contribute_to_community_goals(streamer)
 
         except Exception:
+            message_loggable = "REDACTED" if Settings.logger.anonymiser.strict else message
             logger.error(
-                f"Exception raised for topic: {message.topic} and message: {message}",
+                f"Exception raised for topic: {message.topic} and message: {message_loggable}",
                 exc_info=True,
             )

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -254,7 +254,7 @@ class Twitch(object):
             else:
                 return response.id
         except RetryError as e:
-            logger.error(f"Error getting channel id for {streamer_username}: {e}")
+            logger.error(f"Error getting channel id for {Settings.logger.anonymiser.username(streamer_username)}: {e}")
             raise StreamerDoesNotExistException
 
     def get_followers(

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -203,7 +203,7 @@ class Twitch(object):
                 self.client_session.login.get_user_id(), streamer.channel_id
             )
         except RetryError as e:
-            logger.error(f"Error getting stream info for {streamer.username}: {e}")
+            logger.error(f"Error getting stream info for {Settings.logger.anonymiser.streamer_username(streamer)}: {e}")
             raise e
         if info_response.user.stream is None:
             # There is no stream data, so they're offline
@@ -277,14 +277,15 @@ class Twitch(object):
     def update_raid(self, streamer, raid):
         if streamer.raid != raid:
             streamer.raid = raid
+            target = Settings.logger.anonymiser.username(raid.target_login)
             try:
                 self.gql.join_raid(raid.raid_id)
                 logger.info(
-                    f"Joining raid from {streamer} to {raid.target_login}!",
+                    f"Joining raid from {streamer} to {target}!",
                     extra={"emoji": ":performing_arts:", "event": Events.JOIN_RAID},
                 )
             except RetryError as e:
-                logger.error(f"Error joining raid from {streamer} to {raid}: {e}")
+                logger.error(f"Error joining raid from {streamer} to {target}: {e}")
 
     # === 'GLOBALS' METHODS === #
     # Create chunk of sleep of speed-up the break loop after CTRL+C
@@ -557,13 +558,13 @@ class Twitch(object):
                     except StreamerDoesNotExistException:
                         failed_streamers.add(streamer.username)
                         logger.info(
-                            f"Streamer {streamer.username} does not exist",
+                            f"Streamer {Settings.logger.anonymiser.streamer_username(streamer)} does not exist",
                             extra={"emoji": ":cry:"},
                         )
                     except Exception:
                         failed_streamers.add(streamer.username)
                         logger.error(
-                            f"Failed to initialize streamer {streamer.username}",
+                            f"Failed to initialize streamer {Settings.logger.anonymiser.streamer_username(streamer)}",
                             exc_info=True,
                         )
             except TimeoutError:
@@ -586,7 +587,9 @@ class Twitch(object):
                 try:
                     self.load_channel_points_context(streamer)
                 except StreamerDoesNotExistException:
-                    logger.warning(f"Detected that Streamer '{streamer.username}' no longer exists.")
+                    logger.warning(
+                        f"Detected that Streamer '{Settings.logger.anonymiser.streamer_username(streamer)}' no longer exists."
+                    )
                     pass
 
     def make_predictions(self, event):
@@ -672,7 +675,7 @@ class Twitch(object):
             self.gql.claim_community_points(streamer.channel_id, claim_id)
         except RetryError as e:
             logger.error(
-                f"Error while trying to claim bonus for {streamer.username}: {e}"
+                f"Error while trying to claim bonus for {Settings.logger.anonymiser.streamer_username(streamer)}: {e}"
             )
 
     # === MOMENTS === #
@@ -687,7 +690,7 @@ class Twitch(object):
             self.gql.claim_moment(moment_id)
         except RetryError as e:
             logger.error(
-                f"Error while trying to claim moment with id {moment_id} for {streamer.username}: {e}",
+                f"Error while trying to claim moment with id {moment_id} for {Settings.logger.anonymiser.streamer_username(streamer)}: {e}",
             )
 
     # === CAMPAIGNS / DROPS / INVENTORY === #
@@ -696,7 +699,7 @@ class Twitch(object):
             return self.gql.get_available_drops(streamer.channel_id).ids
         except RetryError as e:
             logger.error(
-                f"Error while trying to get drops campaign ids for {streamer.username}: {e}"
+                f"Error while trying to get drops campaign ids for {Settings.logger.anonymiser.streamer_username(streamer)}: {e}"
             )
             return []
 
@@ -878,7 +881,7 @@ class Twitch(object):
                 return
             user_goal_contributions = response.goal_contributions
             logger.debug(
-                f"Found {len(user_goal_contributions)} community goals for {streamer.username}'s current stream"
+                f"Found {len(user_goal_contributions)} community goals for {Settings.logger.anonymiser.streamer_username(streamer)}'s current stream"
             )
             for goal_contribution in user_goal_contributions:
                 goal_id = goal_contribution.id
@@ -886,7 +889,7 @@ class Twitch(object):
                 if goal is None:
                     # TODO should this trigger a new load context request
                     logger.error(
-                        f"Unable to find context data for {streamer.username}'s community goal {goal_id}"
+                        f"Unable to find context data for {Settings.logger.anonymiser.streamer_username(streamer)}'s community goal {goal_id}"
                     )
                 else:
                     user_stream_contribution = (
@@ -919,12 +922,12 @@ class Twitch(object):
             )
         except RetryError as e:
             logger.error(
-                f"Error while contributing to channel {streamer.username}'s community goal '{title}', amount {amount}: {e}",
+                f"Error while contributing to channel {Settings.logger.anonymiser.streamer_username(streamer)}'s community goal '{title}', amount {amount}: {e}",
             )
             return
         if response.error is not None:
             logger.error(
-                f"Unable to contribute channel points to {streamer.username}'s community goal '{title}', reason '{response.error}'"
+                f"Unable to contribute channel points to {Settings.logger.anonymiser.streamer_username(streamer)}'s community goal '{title}', reason '{response.error}'"
             )
         else:
             logger.info(

--- a/TwitchChannelPointsMiner/classes/entities/EventPrediction.py
+++ b/TwitchChannelPointsMiner/classes/entities/EventPrediction.py
@@ -48,7 +48,7 @@ class EventPrediction(object):
 
     def __str__(self):
         return (
-            f"EventPrediction: {self.streamer} - {self.title}"
+            f"EventPrediction: {Settings.logger.anonymiser.streamer_username(self.streamer)} - {self.title}"
             if Settings.logger.less
             else self.__repr__()
         )

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -12,6 +12,7 @@ from TwitchChannelPointsMiner.classes.Settings import Events, Settings, Streamer
 from TwitchChannelPointsMiner.classes.gql import Properties
 from TwitchChannelPointsMiner.constants import URL
 from TwitchChannelPointsMiner.utils import millify
+from TwitchChannelPointsMiner.utils.Utils import oxford_comma_list
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +174,13 @@ class Streamer(object):
                 "event": Events.STREAMER_ONLINE,
             },
         )
+        reasons = []
+        if not self.channel_points_enabled:
+            reasons.append("Channel Points are disabled for this channel")
+        if self.chat_banned:
+            reasons.append("your account is banned in this channel's chat")
+        if len(reasons) > 0:
+            logger.warning(f"Cannot mine {self} because {oxford_comma_list(reasons)}.")
 
     def print_history(self):
         return "; ".join(

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -136,11 +136,11 @@ class Streamer(object):
         self.mutex = Lock()
 
     def __repr__(self):
-        return f"Streamer(username={self.username}, channel_id={self.channel_id}, channel_points={millify(self.channel_points)})"
+        return f"Streamer(username={Settings.logger.anonymiser.streamer_username(self)}, channel_id={Settings.logger.anonymiser.streamer_channel_id(self)}, channel_points={millify(Settings.logger.anonymiser.channel_points(self))})"
 
     def __str__(self):
         return (
-            f"{self.username} ({millify(self.channel_points)} points)"
+            f"{Settings.logger.anonymiser.username(self.username)} ({millify(Settings.logger.anonymiser.channel_points(self))} points)"
             if Settings.logger.less
             else self.__repr__()
         )

--- a/TwitchChannelPointsMiner/classes/gql/Integration.py
+++ b/TwitchChannelPointsMiner/classes/gql/Integration.py
@@ -8,7 +8,7 @@ import requests
 from requests import Response
 
 from TwitchChannelPointsMiner.classes.ClientSession import ClientSession
-from TwitchChannelPointsMiner.classes.Settings import FollowersOrder
+from TwitchChannelPointsMiner.classes.Settings import FollowersOrder, Settings
 from TwitchChannelPointsMiner.classes.gql.Errors import (
     GQLError,
     RetryError,
@@ -163,6 +163,56 @@ class GQL:
         self.post_request = requests.post if post_request is None else post_request
         """Function for posting GQL requests."""
 
+    @staticmethod
+    def __redact_request_json(json: dict | list[dict]) -> dict | list[dict]:
+        """
+        Creates a copy of the given request JSON with identifying information redacted.
+
+        TODO It would be nice for this to be a function on each operation
+
+        :param json: The JSON to redact.
+        :return: The redacted JSON.
+        """
+
+        def redact_dict(value: dict) -> dict:
+            value = copy.deepcopy(value)
+            operation_name = value["operationName"]
+            variables = value.get("variables", None)
+            if variables is not None:
+                channel = variables.get("channel", None)
+                if channel is not None:
+                    variables["channel"] = Settings.logger.anonymiser.username(channel)
+                login = variables.get("login", None)
+                if login is not None:
+                    variables["login"] = Settings.logger.anonymiser.username(login)
+                channel_login = variables.get("channelLogin", None)
+                if channel_login is not None:
+                    # Annoyingly "channelLogin" is both a username and a channel id in different operations
+                    if operation_name in [
+                        GQLOperations.ChannelPointsContext["operationName"],
+                        GQLOperations.UserPointsContribution["operationName"]
+                    ]:
+                        variables["channelLogin"] = Settings.logger.anonymiser.username(channel_login)
+                    elif operation_name == GQLOperations.DropCampaignDetails["operationName"]:
+                        variables["channelLogin"] = Settings.logger.anonymiser.channel_id(channel_login)
+                channel_id = variables.get("channelID", None)
+                if channel_id is not None:
+                    variables["channelID"] = Settings.logger.anonymiser.channel_id(channel_id)
+                if operation_name == GQLOperations.WithIsStreamLiveQuery["operationName"]:
+                    variables["id"] = Settings.logger.anonymiser.channel_id(variables["id"])
+                target_user_id = variables.get("targetUserID", None)
+                if target_user_id is not None:
+                    variables["targetUserID"] = Settings.logger.anonymiser.channel_id(target_user_id)
+            return value
+
+        if isinstance(json, dict):
+            return redact_dict(json)
+        else:
+            result = []
+            for item in json:
+                result.append(redact_dict(item))
+            return result
+
     def __post_gql_request(self, request_json: dict | list[dict]) -> Any:
         response = self.post_request(
             GQLOperations.url,
@@ -176,8 +226,11 @@ class GQL:
                 "X-Device-Id": self.client_session.device_id,
             },
         )
+
+        redacted_request_json = self.__redact_request_json(request_json)
+
         logger.debug(
-            f"Data: {request_json}, Status code: {response.status_code}, Content: {response.text}"
+            f"Data: {redacted_request_json}, Status code: {response.status_code}, Content: {response.text}"
         )
         response.raise_for_status()
         return response.json()

--- a/TwitchChannelPointsMiner/classes/gql/Integration.py
+++ b/TwitchChannelPointsMiner/classes/gql/Integration.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import sys
 import traceback
 from secrets import token_hex
 from typing import Callable, Any, Protocol
@@ -85,7 +86,7 @@ def error_context(e: Exception) -> str | None:
     :return: The context string, or None if no context is needed.
     """
     if not isinstance(e, GQLError):
-        return traceback.format_exc()
+        return Settings.logger.anonymiser.format_exception((type(e), e, e.__traceback__))
     else:
         return None
 

--- a/TwitchChannelPointsMiner/classes/gql/Integration.py
+++ b/TwitchChannelPointsMiner/classes/gql/Integration.py
@@ -229,8 +229,10 @@ class GQL:
 
         redacted_request_json = self.__redact_request_json(request_json)
 
+        response_text = "REDACTED" if Settings.logger.anonymiser.strict else response.text
+
         logger.debug(
-            f"Data: {redacted_request_json}, Status code: {response.status_code}, Content: {response.text}"
+            f"Data: {redacted_request_json}, Status code: {response.status_code}, Content: {response_text}"
         )
         response.raise_for_status()
         return response.json()

--- a/TwitchChannelPointsMiner/classes/websocket/hermes/Client.py
+++ b/TwitchChannelPointsMiner/classes/websocket/hermes/Client.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 import json
 import logging
 import threading
@@ -153,6 +154,22 @@ class HermesClient(WebSocketApp):
         if do_close:
             super().close()
 
+    @staticmethod
+    def redact_request(request: Request) -> Request:
+        """
+        Redacts a Request by removing authentication tokens and anonymising channel ids.
+
+        :param request:
+        :return:
+        """
+        if isinstance(request, AuthenticateRequest):
+            request.authenticate.token = "REDACTED"
+        else:
+            request = copy.deepcopy(request)
+            request.subscribe.pubsub.topic = Settings.logger.anonymiser.topic(request.subscribe.pubsub.topic)
+        return request
+
+
     def __send_request(self, request: Request):
         """
         Sends a request to the remote server.
@@ -161,9 +178,8 @@ class HermesClient(WebSocketApp):
         """
         try:
             data = self.json_encoder.encode(request)
-            logger.debug(
-                f"{self.describe()} - Send: {"AuthenticateRequest(REDACTED)" if isinstance(request, AuthenticateRequest) else data}"
-            )
+            redacted_data = self.json_encoder.encode(self.redact_request(request))
+            logger.debug(f"{self.describe()} - Send: {redacted_data}")
             self.send(data)
             return True
         except WebSocketConnectionClosedException:
@@ -366,7 +382,7 @@ class HermesClient(WebSocketApp):
                 if isinstance(response, NotificationResponse):
                     topic = client.topic(response.notification.subscription.id)
                     logger.error(
-                        f"{client.describe()} - Exception raised for topic: {str(topic)} and message: {message}",
+                        f"{client.describe()} - Exception raised for topic: {Settings.logger.anonymiser.topic(topic)} and message: {message}",
                         exc_info=e
                     )
                 else:

--- a/TwitchChannelPointsMiner/classes/websocket/hermes/Client.py
+++ b/TwitchChannelPointsMiner/classes/websocket/hermes/Client.py
@@ -353,7 +353,8 @@ class HermesClient(WebSocketApp):
         :param client: The client that received the message.
         :param message: The message that was received.
         """
-        logger.debug(f"{client.describe()} - Received: {message.strip()}")
+        message_loggable = "REDACTED" if Settings.logger.anonymiser.strict else message.strip()
+        logger.debug(f"{client.describe()} - Received: {message_loggable}")
         client.last_message_time = datetime.now()
         try:
             response = client.json_decoder.decode(message)
@@ -377,16 +378,16 @@ class HermesClient(WebSocketApp):
                     for listener in client.listeners:
                         listener.on_reconnect(client, response.reconnect.url)
                 else:
-                    logger.error(f"{client.describe()} - Unknown response: {response}")
+                    logger.error(f"{client.describe()} - Unknown response: {type(response)}")
             except Exception as e:
                 if isinstance(response, NotificationResponse):
                     topic = client.topic(response.notification.subscription.id)
                     logger.error(
-                        f"{client.describe()} - Exception raised for topic: {Settings.logger.anonymiser.topic(topic)} and message: {message}",
+                        f"{client.describe()} - Exception raised for topic: {Settings.logger.anonymiser.topic(topic)} and message: {message_loggable}",
                         exc_info=e
                     )
                 else:
-                    logger.error(f"{client.describe()} - Exception raised for response: {response}", exc_info=e)
+                    logger.error(f"{client.describe()} - Exception raised for response: {type(response)}", exc_info=e)
                 HermesClient.on_error(client, e)
         except (json.JSONDecodeError, ValueError) as e:
             HermesClient.on_error(client, e)

--- a/TwitchChannelPointsMiner/classes/websocket/hermes/Pool.py
+++ b/TwitchChannelPointsMiner/classes/websocket/hermes/Pool.py
@@ -7,6 +7,7 @@ from typing import Iterable
 from websocket import WebSocketConnectionClosedException
 
 from TwitchChannelPointsMiner.classes.PubSub import MessageListener
+from TwitchChannelPointsMiner.classes.Settings import Settings
 from TwitchChannelPointsMiner.classes.Twitch import Twitch
 from TwitchChannelPointsMiner.classes.TwitchLogin import TwitchLogin
 from TwitchChannelPointsMiner.classes.entities.Message import Message
@@ -251,7 +252,10 @@ class HermesWebSocketPool(WebSocketPool, HermesWebSocketListener):
             self.__reconnect(client)
         else:
             # Don't pass the error since we can't actually confirm it's an Exception
-            logger.error(f"{client.describe()} - WebSocket error: {error}", exc_info=isinstance(error, BaseException))
+            logger.error(
+                f"{client.describe()} - WebSocket error: {error}",
+                exc_info=(not Settings.logger.less) and isinstance(error, BaseException)
+            )
 
     def start(self):
         logger.debug(f"Starting Hermes WebSocket Pool")

--- a/TwitchChannelPointsMiner/classes/websocket/hermes/Pool.py
+++ b/TwitchChannelPointsMiner/classes/websocket/hermes/Pool.py
@@ -125,7 +125,7 @@ class HermesWebSocketPool(WebSocketPool, HermesWebSocketListener):
         """
         with self.__lock:
             if self.__subscribed(topic):
-                logger.debug(f"Already subscribed to topic, {topic}")
+                logger.debug(f"Already subscribed to topic, {Settings.logger.anonymiser.topic(topic)}")
             else:
                 self.__next_available_client().subscribe(topic)
 
@@ -156,7 +156,9 @@ class HermesWebSocketPool(WebSocketPool, HermesWebSocketListener):
         time.sleep(30)
         while not internet_connection_available() and not self.force_close:
             random_sleep = random.randint(1, 3)
-            logger.warning(f"{client.describe()} - No internet connection available! Retrying websocket reconnection after {random_sleep}m")
+            logger.warning(
+                f"{client.describe()} - No internet connection available! Retrying websocket reconnection after {random_sleep}m"
+            )
             time.sleep(random_sleep * 60)
         if not self.force_close:
             # Don't bother opening the new client if between creation and now the pool has closed
@@ -211,7 +213,7 @@ class HermesWebSocketPool(WebSocketPool, HermesWebSocketListener):
                     listener.on_message(message)
             else:
                 logger.warning(
-                    f"{client.describe()} - Unable to find topic for subscription {notification.subscription.id}"
+                    f"{client.describe()} - Unable to find topic for subscription {Settings.logger.anonymiser.hermes_subscription_id(notification.subscription.id)}"
                 )
         else:
             logger.warning(f"{client.describe()} - Received unknown notification type {type(notification)}")

--- a/TwitchChannelPointsMiner/classes/websocket/pubsub/Client.py
+++ b/TwitchChannelPointsMiner/classes/websocket/pubsub/Client.py
@@ -4,6 +4,7 @@ import time
 
 from websocket import WebSocketApp, WebSocketConnectionClosedException
 
+from TwitchChannelPointsMiner.classes.Settings import Settings
 from TwitchChannelPointsMiner.utils import create_nonce
 
 logger = logging.getLogger(__name__)
@@ -48,9 +49,34 @@ class PubSubWebSocket(WebSocketApp):
         self.send({"type": "PING"})
         self.last_ping = time.time()
 
-    def send(self, request):
+    @staticmethod
+    def _redact_request(request: dict):
+        """
+        Redacts the auth token from the given request in place.
+
+        :param request: The request to redact.
+        """
+        if "data" in request:
+            data = request["data"]
+            if "auth_token" in data:
+                data["auth_token"] = "REDACTED"
+
+    @staticmethod
+    def _format_request(request: dict):
+        """
+        Formats the given request into a JSON string.
+
+        :param request: The request to format.
+        :return: The formatted request.
+        """
+        return json.dumps(request, separators=(",", ":"))
+
+    def send(self, request: dict):
         try:
-            request_str = json.dumps(request, separators=(",", ":"))
+            request_str = self._format_request(request)
+            if Settings.logger.redact_secrets:
+                self._redact_request(request)
+                request_str = self._format_request(request)
             logger.debug(f"#{self.index} - Send: {request_str}")
             super().send(request_str)
         except WebSocketConnectionClosedException:

--- a/TwitchChannelPointsMiner/classes/websocket/pubsub/Client.py
+++ b/TwitchChannelPointsMiner/classes/websocket/pubsub/Client.py
@@ -52,7 +52,7 @@ class PubSubWebSocket(WebSocketApp):
     @staticmethod
     def _redact_request(request: dict):
         """
-        Redacts the auth token from the given request in place.
+        Redacts the auth token and channel id from the given request in place if they exist.
 
         :param request: The request to redact.
         """
@@ -60,6 +60,8 @@ class PubSubWebSocket(WebSocketApp):
             data = request["data"]
             if "auth_token" in data:
                 data["auth_token"] = "REDACTED"
+            if "topics" in data:
+                data["topics"] = Settings.logger.anonymiser.topic(data["topics"])
 
     @staticmethod
     def _format_request(request: dict):

--- a/TwitchChannelPointsMiner/classes/websocket/pubsub/Pool.py
+++ b/TwitchChannelPointsMiner/classes/websocket/pubsub/Pool.py
@@ -211,9 +211,8 @@ class PubSubWebSocketPool(WebSocketPool):
             # Check if the error message indicates an authentication issue (ERR_BADAUTH)
             if "ERR_BADAUTH" in error_message:
                 # Inform the user about the potential outdated cookie file
-                username = ws.twitch.client_session.twitch_login.username
                 logger.error(
-                    f"Received the ERR_BADAUTH error, most likely you have an outdated cookie file \"cookies\\{username}.pkl\". Delete this file and try again."
+                    f"Received the ERR_BADAUTH error, most likely you have an outdated cookie file \"cookies\\[your username].pkl\". Delete this file and try again."
                 )
                 # Attempt to delete the outdated cookie file
                 # try:

--- a/TwitchChannelPointsMiner/classes/websocket/pubsub/Pool.py
+++ b/TwitchChannelPointsMiner/classes/websocket/pubsub/Pool.py
@@ -180,7 +180,8 @@ class PubSubWebSocketPool(WebSocketPool):
 
     @staticmethod
     def on_message(ws: PubSubWebSocket, message: str):
-        logger.debug(f"#{ws.index} - Received: {message.strip()}")
+        message_loggable = "REDACTED" if Settings.logger.anonymiser.strict else message.strip()
+        logger.debug(f"#{ws.index} - Received: {message_loggable}")
         response = json.loads(message)
 
         if response["type"] == "MESSAGE":

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -142,6 +142,16 @@ class LoggerSettings:
             self.anonymiser: Anonymiser = anonymiser
 
 
+class ExceptionFormatter(logging.Formatter):
+    """Formatter that delegates formatting Exceptions to the Settings' Anonymiser."""
+    def __init__(self, settings: LoggerSettings):
+        self.settings = settings
+        super().__init__()
+
+    def formatException(self, ei):
+        return self.settings.anonymiser.format_exception(ei)
+
+
 class FileFormatter(logging.Formatter):
     def __init__(self, *, fmt, settings: LoggerSettings, datefmt=None):
         self.settings = settings
@@ -162,9 +172,6 @@ class FileFormatter(logging.Formatter):
         else:
             dt = datetime.fromtimestamp(record.created)
         return dt.strftime(datefmt or self.default_time_format)
-
-    def formatException(self, ei):
-        return self.settings.anonymiser.format_exception(ei)
 
 
 class GlobalFormatter(logging.Formatter):
@@ -224,11 +231,7 @@ class GlobalFormatter(logging.Formatter):
                 record.msg = (
                     f"{self.settings.color_palette.get(record.event)}{record.msg}"
                 )
-
         return super().format(record)
-
-    def formatException(self, ei):
-        return self.settings.anonymiser.format_exception(ei)
 
 
 def configure_loggers(username, settings):
@@ -238,6 +241,7 @@ def configure_loggers(username, settings):
     # Queue handler that will handle the logger queue
     logger_queue = queue.Queue(-1)
     queue_handler = QueueHandler(logger_queue)
+    queue_handler.setFormatter(ExceptionFormatter(settings=settings))
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
     # Add the queue handler to the root logger

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -83,7 +83,8 @@ class LoggerSettings:
         "pushover",
         "gotify",
         "hooks",
-        "username"
+        "username",
+        "redact_secrets",
     ]
 
     def __init__(
@@ -105,7 +106,8 @@ class LoggerSettings:
         pushover: Pushover | None = None,
         gotify: Gotify |None = None,
         hooks: list[EventHook] | None = None,
-        username: str | None = None
+        username: str | None = None,
+        redact_secrets: bool = False,
     ):
         self.save = save
         self.less = less
@@ -128,6 +130,7 @@ class LoggerSettings:
                                                self.gotify]
         self.hooks.extend(hook for hook in named_hooks if hook is not None)
         self.username = username
+        self.redact_secrets = redact_secrets
 
 
 class FileFormatter(logging.Formatter):

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -2,24 +2,24 @@ import logging
 import os
 import platform
 import queue
-import pytz
 import sys
 from datetime import datetime
 from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
 from pathlib import Path
 
 import emoji
+import pytz
 from colorama import Fore, init
 
 from TwitchChannelPointsMiner.classes.Anonymiser import Anonymiser, ConsistentAnonymiser, Deanonymiser
 from TwitchChannelPointsMiner.classes.Discord import Discord
 from TwitchChannelPointsMiner.classes.EventHook import EventHook
-from TwitchChannelPointsMiner.classes.Webhook import Webhook
+from TwitchChannelPointsMiner.classes.Gotify import Gotify
 from TwitchChannelPointsMiner.classes.Matrix import Matrix
+from TwitchChannelPointsMiner.classes.Pushover import Pushover
 from TwitchChannelPointsMiner.classes.Settings import Events
 from TwitchChannelPointsMiner.classes.Telegram import Telegram
-from TwitchChannelPointsMiner.classes.Pushover import Pushover
-from TwitchChannelPointsMiner.classes.Gotify import Gotify
+from TwitchChannelPointsMiner.classes.Webhook import Webhook
 from TwitchChannelPointsMiner.utils import remove_emoji
 
 
@@ -106,7 +106,7 @@ class LoggerSettings:
         webhook: Webhook | None = None,
         matrix: Matrix | None = None,
         pushover: Pushover | None = None,
-        gotify: Gotify |None = None,
+        gotify: Gotify | None = None,
         hooks: list[EventHook] | None = None,
         username: str | None = None,
         redact_secrets: bool = False,
@@ -152,7 +152,8 @@ class FileFormatter(logging.Formatter):
                 logging.info(f"File logger time zone set to: {self.timezone}")
             except pytz.UnknownTimeZoneError:
                 logging.error(
-                    f"File logger: invalid time zone: {settings.time_zone}")
+                    f"File logger: invalid time zone: {settings.time_zone}"
+                )
         logging.Formatter.__init__(self, fmt=fmt, datefmt=datefmt)
 
     def formatTime(self, record, datefmt=None):
@@ -161,6 +162,9 @@ class FileFormatter(logging.Formatter):
         else:
             dt = datetime.fromtimestamp(record.created)
         return dt.strftime(datefmt or self.default_time_format)
+
+    def formatException(self, ei):
+        return self.settings.anonymiser.format_exception(ei)
 
 
 class GlobalFormatter(logging.Formatter):
@@ -171,10 +175,12 @@ class GlobalFormatter(logging.Formatter):
             try:
                 self.timezone = pytz.timezone(settings.time_zone)
                 logging.info(
-                    f"Console logger time zone set to: {self.timezone}")
+                    f"Console logger time zone set to: {self.timezone}"
+                )
             except pytz.UnknownTimeZoneError:
                 logging.error(
-                    f"Console logger: invalid time zone: {settings.time_zone}")
+                    f"Console logger: invalid time zone: {settings.time_zone}"
+                )
         logging.Formatter.__init__(self, fmt=fmt, datefmt=datefmt)
 
     def formatTime(self, record, datefmt=None):
@@ -187,12 +193,13 @@ class GlobalFormatter(logging.Formatter):
     def format(self, record):
         record.emoji_is_present = (
             record.emoji_is_present if hasattr(
-                record, "emoji_is_present") else False
+                record, "emoji_is_present"
+            ) else False
         )
         if (
-            hasattr(record, "emoji")
-            and self.settings.emoji is True
-            and record.emoji_is_present is False
+                hasattr(record, "emoji")
+                and self.settings.emoji is True
+                and record.emoji_is_present is False
         ):
             record.msg = emoji.emojize(
                 f"{record.emoji}  {record.msg.strip()}", language="alias"
@@ -219,6 +226,10 @@ class GlobalFormatter(logging.Formatter):
                 )
 
         return super().format(record)
+
+    def formatException(self, ei):
+        return self.settings.anonymiser.format_exception(ei)
+
 
 def configure_loggers(username, settings):
     if settings.colored is True:

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import emoji
 from colorama import Fore, init
 
+from TwitchChannelPointsMiner.classes.Anonymiser import Anonymiser, ConsistentAnonymiser, Deanonymiser
 from TwitchChannelPointsMiner.classes.Discord import Discord
 from TwitchChannelPointsMiner.classes.EventHook import EventHook
 from TwitchChannelPointsMiner.classes.Webhook import Webhook
@@ -85,6 +86,7 @@ class LoggerSettings:
         "hooks",
         "username",
         "redact_secrets",
+        "anonymiser",
     ]
 
     def __init__(
@@ -108,6 +110,7 @@ class LoggerSettings:
         hooks: list[EventHook] | None = None,
         username: str | None = None,
         redact_secrets: bool = False,
+        anonymiser: Anonymiser | bool | None = None
     ):
         self.save = save
         self.less = less
@@ -131,6 +134,12 @@ class LoggerSettings:
         self.hooks.extend(hook for hook in named_hooks if hook is not None)
         self.username = username
         self.redact_secrets = redact_secrets
+        if anonymiser is None or anonymiser is False:
+            self.anonymiser: Anonymiser = Deanonymiser()
+        elif anonymiser is True:
+            self.anonymiser: Anonymiser = ConsistentAnonymiser()
+        else:
+            self.anonymiser: Anonymiser = anonymiser
 
 
 class FileFormatter(logging.Formatter):

--- a/TwitchChannelPointsMiner/utils/Utils.py
+++ b/TwitchChannelPointsMiner/utils/Utils.py
@@ -3,6 +3,7 @@ import re
 import secrets
 import socket
 import time
+import uuid
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from os import path
@@ -342,3 +343,12 @@ def oxford_comma_list(items: Sequence[str]) -> str:
     if len(items) == 2:
         return f"{items[0]} and {items[1]}"
     return ", ".join(items[:-1]) + f", and {items[-1]}"
+
+
+def generate_random_uuid() -> str:
+    """
+    Generates a random UUID as a string.
+
+    :return: The UUID.
+    """
+    return str(uuid.uuid4())

--- a/TwitchChannelPointsMiner/utils/Utils.py
+++ b/TwitchChannelPointsMiner/utils/Utils.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from os import path
 from random import randrange
-from typing import TypeVar, Iterable, Callable
+from typing import Sequence, TypeVar, Iterable, Callable
 
 import requests
 from millify import millify as package_millify
@@ -319,3 +319,26 @@ def interruptible_repeating_task(
             next_sleep_duration = max(0.0, next_run_time - time.time())
         else:
             break
+
+def oxford_comma_list(items: Sequence[str]) -> str:
+    """
+    Formats a list of strings as an Oxford comma list. i.e.
+
+    `[]` -> `""`
+
+    `["a"]` -> `"a"`
+
+    `["a", "b"]` -> `"a and b"`
+
+    `["a", "b", "c"]` -> `"a, b, and c"`
+
+    :param items: The items to format.
+    :return: The formatted string.
+    """
+    if len(items) == 0:
+        return ""
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return ", ".join(items[:-1]) + f", and {items[-1]}"

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -642,6 +642,11 @@ currently affects PubSub request logging.
 
 ### `anonymiser`
 
+> [!NOTE]
+> Credit to [Klaro](https://github.com/0x8fv) and their
+> work [here](https://github.com/0x8fv/Twitch-Channel-Points-Miner/blob/940c98409e5821900752815cd9550ae5b750b597/TwitchChannelPointsMiner/privacy/anonymizer.go)
+> for inspiring this feature!
+
 > [!WARNING]
 > While this does work for logged information the miner _**itself**_ generates, it cannot work for information
 > _**received**_ from external sources like the Twitch GQL and WebSocket APIs.
@@ -650,6 +655,104 @@ Set this to `True` to automatically anonymise, to the extent possible, all ident
 works for channel ids, usernames, points, WebSocket topics, and Hermes subscription ids.
 
 By default, this is set to `False`. Setting it to `False` or `None` will cause no information to be anonymised.
+
+*Example logs:*
+```text
+12/03 09:18:52 - Twitch Channel Points Miner-1.1.0 (fork by mpforce1)
+12/03 09:18:52 - https://github.com/mpforce1/Twitch-Channel-Points-Miner
+12/03 09:18:54 - 🌐  Analytics running on http://0.0.0.0:5000/
+12/03 09:18:54 - 💣  Start session: 'a0ae3a4d-2cf8-4573-bfg1-a310a060a930'
+12/03 09:18:54 - 🤓  Loading data for 17 streamers. Please wait...
+12/03 09:18:56 - 😴  Streamer7 (195.37k points) is Offline!
+12/03 09:18:56 - 😴  Streamer6 (757.73k points) is Offline!
+12/03 09:18:56 - 😴  Streamer4 (265.12k points) is Offline!
+12/03 09:18:56 - 😴  Streamer1 (517.41k points) is Offline!
+12/03 09:18:56 - 🚀  Detected WATCH_STREAK for Streamer9 (989.18k points)
+12/03 09:18:56 - 😴  Streamer2 (747.28k points) is Offline!
+12/03 09:18:56 - 😴  Streamer10 (559.75k points) is Offline!
+12/03 09:18:56 - 😴  Streamer5 (696.38k points) is Offline!
+12/03 09:18:56 - 😴  Streamer8 (505.82k points) is Offline!
+12/03 09:18:56 - 💬  Join IRC Chat: Streamer3
+12/03 09:18:56 - 🥳  Streamer3 (157.89k points) is Online!
+12/03 09:18:56 - 💬  Join IRC Chat: Streamer9
+12/03 09:18:56 - 🥳  Streamer9 (989.18k points) is Online!
+12/03 09:18:58 - 🚀  Detected WATCH_STREAK for Streamer16 (174.22k points)
+12/03 09:18:58 - 😴  Streamer17 (320.06k points) is Offline!
+12/03 09:18:58 - 😴  Streamer12 (803.47k points) is Offline!
+12/03 09:18:58 - 🚀  Detected WATCH_STREAK for Streamer11 (370.13k points)
+12/03 09:18:58 - 😴  Streamer13 (503.6k points) is Offline!
+12/03 09:18:58 - 😴  Streamer14 (242.69k points) is Offline!
+12/03 09:18:58 - 🚀  Detected WATCH_STREAK for Streamer15 (364.78k points)
+12/03 09:18:58 - 💬  Join IRC Chat: Streamer11
+12/03 09:18:58 - 🥳  Streamer11 (370.13k points) is Online!
+12/03 09:18:59 - 💬  Join IRC Chat: Streamer15
+12/03 09:18:59 - 🥳  Streamer15 (364.78k points) is Online!
+12/03 09:18:59 - 💬  Join IRC Chat: Streamer16
+12/03 09:18:59 - 🥳  Streamer16 (174.22k points) is Online!
+12/03 09:37:21 - 🚀  +10 → Streamer9 (989.19k points) - Reason: WATCH.
+12/03 09:38:12 - 🚀  +10 → Streamer3 (157.9k points) - Reason: WATCH.
+12/03 09:42:21 - 🚀  +10 → Streamer9 (989.2k points) - Reason: WATCH.
+12/03 09:43:12 - 🚀  +10 → Streamer3 (157.91k points) - Reason: WATCH.
+12/03 09:47:22 - 🚀  +10 → Streamer9 (989.21k points) - Reason: WATCH.
+12/03 09:47:22 - 🚀  +50 → Streamer9 (989.26k points) - Reason: CLAIM.
+12/03 09:48:10 - 🚀  +10 → Streamer3 (157.92k points) - Reason: WATCH.
+12/03 09:48:10 - 🚀  +50 → Streamer3 (157.97k points) - Reason: CLAIM.
+12/03 09:52:20 - 🚀  +10 → Streamer9 (989.27k points) - Reason: WATCH.
+12/03 09:53:12 - 🚀  +10 → Streamer3 (157.98k points) - Reason: WATCH.
+12/03 09:57:21 - 🚀  +10 → Streamer9 (989.28k points) - Reason: WATCH.
+12/03 09:58:12 - 🚀  +10 → Streamer3 (157.99k points) - Reason: WATCH.
+12/03 10:02:22 - 🚀  +10 → Streamer9 (989.29k points) - Reason: WATCH.
+12/03 10:02:22 - 🚀  +50 → Streamer9 (989.34k points) - Reason: CLAIM.
+12/03 10:03:11 - 🚀  +10 → Streamer3 (158k points) - Reason: WATCH.
+12/03 10:03:11 - 🚀  +50 → Streamer3 (158.05k points) - Reason: CLAIM.
+12/03 10:04:50 - 🎭  Joining raid from Streamer15 (364.78k points) to Streamer18!
+12/03 10:05:08 - 🚀  +250 → Streamer15 (365.03k points) - Reason: RAID.
+12/03 10:05:26 - 💬  Leave IRC Chat: Streamer15
+12/03 10:05:26 - 😴  Streamer15 (365.03k points) is Offline!
+12/03 10:07:22 - 🚀  +10 → Streamer9 (989.35k points) - Reason: WATCH.
+12/03 10:08:13 - 🚀  +10 → Streamer3 (158.06k points) - Reason: WATCH.
+12/03 10:10:26 - 🚀  +10 → Streamer9 (989.36k points) - Reason: WATCH.
+12/03 10:13:12 - 🚀  +10 → Streamer3 (158.07k points) - Reason: WATCH.
+12/03 10:17:22 - 🚀  +10 → Streamer9 (989.37k points) - Reason: WATCH.
+12/03 10:17:22 - 🚀  +50 → Streamer9 (989.42k points) - Reason: CLAIM.
+12/03 10:18:12 - 🚀  +10 → Streamer3 (158.08k points) - Reason: WATCH.
+12/03 10:18:12 - 🚀  +50 → Streamer3 (158.13k points) - Reason: CLAIM.
+12/03 10:22:22 - 🚀  +10 → Streamer9 (989.43k points) - Reason: WATCH.
+12/03 10:23:13 - 🚀  +10 → Streamer3 (158.14k points) - Reason: WATCH.
+12/03 10:27:22 - 🚀  +10 → Streamer9 (989.44k points) - Reason: WATCH.
+12/03 10:28:12 - 🚀  +10 → Streamer3 (158.15k points) - Reason: WATCH.
+12/03 10:32:21 - 🚀  +10 → Streamer9 (989.45k points) - Reason: WATCH.
+12/03 10:32:21 - 🚀  +50 → Streamer9 (989.5k points) - Reason: CLAIM.
+12/03 10:33:13 - 🚀  +10 → Streamer3 (158.16k points) - Reason: WATCH.
+12/03 10:33:13 - 🚀  +50 → Streamer3 (158.21k points) - Reason: CLAIM.
+12/03 10:37:22 - 🚀  +10 → Streamer9 (989.51k points) - Reason: WATCH.
+12/03 10:38:12 - 🚀  +10 → Streamer3 (158.22k points) - Reason: WATCH.
+12/03 10:42:22 - 🚀  +10 → Streamer9 (989.52k points) - Reason: WATCH.
+12/03 10:43:12 - 🚀  +10 → Streamer3 (158.23k points) - Reason: WATCH.
+12/03 10:43:29 - CTRL+C Detected! Please wait just a moment!
+12/03 10:43:29 - 💬  Leave IRC Chat: Streamer3
+12/03 10:43:29 - 💬  Leave IRC Chat: Streamer9
+12/03 10:43:29 - 💬  Leave IRC Chat: Streamer16
+12/03 10:43:29 - 💬  Leave IRC Chat: Streamer11
+
+
+
+12/03 10:43:38 - 🛑  Ending session: 'a0ae3a4d-2cf8-4573-bfg1-a310a060a930'
+12/03 10:43:38 - 📄  Logs file: /usr/src/app/logs/Streamer19.log
+12/03 10:43:38 - ⌛  Duration 1:24:46.543687
+12/03 10:43:38 - 💰  Streamer3 (158.23k points), Total Points Gained: 340
+                         CLAIM (4 times, 200 gained)
+                         WATCH (14 times, 140 gained)
+12/03 10:43:38 - 💰  Streamer9 (989.52k points), Total Points Gained: 340
+                         CLAIM (4 times, 200 gained)
+                         WATCH (14 times, 140 gained)
+12/03 10:43:38 - 💰  Streamer15 (365.03k points), Total Points Gained: 250
+                         RAID (1 times, 250 gained)
+```
+
+You can see in this example that the amount of points gained from start to end for each Streamer is consistent, along
+with the streamer usernames. Even the `Logs file` path is anonymised, keep this in mind since this should actually be
+in a file named with your real username.
 
 #### `ConsistentAnonymiser`
 
@@ -677,8 +780,9 @@ ConsistentAnonymiser(
 `random_points_min` to `random_points_max` defines the range of possible values when generating the initial random
 channel points for a Streamer. In this example, channel points will be in the range `100` to `1_000_000`.
 
-`random_source` mostly exists for testing. It allows you to override the way randomness is generated. By default it uses
-the built-in function `random.randint` and `uuid.v4` to generate channel points and UUIDs.
+`random_source` mostly exists for testing. It allows you to override the way randomness is generated. By default, it
+uses the built-in functions [`random.randint`](https://docs.python.org/3/library/random.html#random.randint) and
+[`uuid.v4`](https://docs.python.org/3/library/uuid.html#uuid.uuid4) to generate channel points and UUIDs.
 
 #### `Deanonymiser`
 

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -27,6 +27,8 @@ expand more on their usage.
 | `logger_settings`               | `LoggerSettings`                                     | (see [here](#logger_settings))                      |
 | `streamer_settings`             | `StreamerSettings`                                   | (see [here](#streamer_settings))                    |
 | `gql`                           | `AttemptStrategy` or `GQLFactory`                    | `GQLFactory`                                        |
+| `redact_secrets`                | `bool`                                               | `False`                                             |
+| `anonymiser`                    | `Anonymiser` or `bool` or `None`                     | `None`                                              |
 
 ### `username`
 
@@ -632,6 +634,72 @@ parsing the json returned from the GQL API into usable types. `post_request` is 
 to the API. We don't expect most users to need to do more than override the `attempt_strategy`, which is why we allow
 passing that directly to the value of `gql`. Advanced users can also override the factory type for even more
 customization, perhaps returning a custom subclass of `GQL` that overrides the original behaviour entirely.
+
+### `redact_secrets`
+
+Set this to `True` to have secrets (passwords and authentication tokens) redacted from the logs. In particular, this
+currently affects PubSub request logging.
+
+### `anonymiser`
+
+> [!WARNING]
+> While this does work for logged information the miner _**itself**_ generates, it cannot work for information
+> _**received**_ from external sources like the Twitch GQL and WebSocket APIs.
+
+Set this to `True` to automatically anonymise, to the extent possible, all identifying information in the logs. This
+works for channel ids, usernames, points, WebSocket topics, and Hermes subscription ids.
+
+By default, this is set to `False`. Setting it to `False` or `None` will cause no information to be anonymised.
+
+#### `ConsistentAnonymiser`
+
+This is the `Anonymiser` used when `anonymiser` is set to `True`, it will generate random values for each type of
+anonymised data and return the same random value each time that same data is requested. For example, say a Streamer with
+username `bingo` gets logged, the anonymiser may anonymise them as `Streamer5`. Each time the username for this streamer
+is logged, it will log `Streamer5`.
+
+In addition, when logging channel points only the initial value is randomised. As that channel gains/loses points the
+amount logged will reflect the change amount. For example, a channel has `500` points which gets randomised to `2000`
+points. The value you'll initially see logged will be `2000`. If they then gain `50` points you'll see `2050` points
+logged.
+
+```python3
+ConsistentAnonymiser(
+    random_points_min=100,
+    random_points_max=1_000_000,
+    random_source=RandomSource(
+        random_int=random.randint,
+        random_uuid=generate_random_uuid,
+    )
+)
+```
+
+`random_points_min` to `random_points_max` defines the range of possible values when generating the initial random
+channel points for a Streamer. In this example, channel points will be in the range `100` to `1_000_000`.
+
+`random_source` mostly exists for testing. It allows you to override the way randomness is generated. By default it uses
+the built-in function `random.randint` and `uuid.v4` to generate channel points and UUIDs.
+
+#### `Deanonymiser`
+
+This is the `Anonymiser` used when `anonymiser` is set to `False`. It does not alter information.
+
+#### `RandomAnonymiser`
+
+This anonymises information in a more random way. Unlike `ConsistentAnonymiser`, each value is randomly generated each
+time it is logged. For example, a Streamer's username might be `Streamer5` the first time it's logged and `Streamer100`
+the next time.
+
+```python3
+RandomAnonymiser(
+    random_source=RandomSource(
+        random_int=random.randint,
+        random_uuid=generate_random_uuid,
+    )
+)
+```
+
+Configuration for the `RandomSource` is the same as `ConsistentAnonymiser`.
 
 ## `TwitchChannelPointsMiner.mine`
 

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -754,6 +754,12 @@ You can see in this example that the amount of points gained from start to end f
 with the streamer usernames. Even the `Logs file` path is anonymised, keep this in mind since this should actually be
 in a file named with your real username.
 
+All the following anonymisers can optionally specify a boolean for the `strict` parameter. If this is set to `True` then
+all web API responses will be redacted. This is useful because we cannot guarantee that text the miner didn't create
+doesn't contain data that should be anonymised. You can optionally set it to `False` to allow logging these responses.
+This can be useful if it's not possible to debug an issue without checking the response text although it comes with more
+risk of leaking data that you might want anonymised.
+
 #### `ConsistentAnonymiser`
 
 This is the `Anonymiser` used when `anonymiser` is set to `True`, it will generate random values for each type of
@@ -768,14 +774,17 @@ logged.
 
 ```python3
 ConsistentAnonymiser(
+    strict=True,
     random_points_min=100,
     random_points_max=1_000_000,
     random_source=RandomSource(
         random_int=random.randint,
         random_uuid=generate_random_uuid,
-    )
+    ),
 )
 ```
+
+`strict` is `True` by default for this anonymiser. It can be set to `False` if you want API responses to be logged.
 
 `random_points_min` to `random_points_max` defines the range of possible values when generating the initial random
 channel points for a Streamer. In this example, channel points will be in the range `100` to `1_000_000`.
@@ -786,7 +795,14 @@ uses the built-in functions [`random.randint`](https://docs.python.org/3/library
 
 #### `Deanonymiser`
 
-This is the `Anonymiser` used when `anonymiser` is set to `False`. It does not alter information.
+This is the `Anonymiser` used when `anonymiser` is set to `False`. It does not alter information. `strict` is set to
+`False` for this anonymiser, but you can set it to `True` if you want that behaviour.
+
+```python3
+Deanonymiser(
+    strict=False
+)
+```
 
 #### `RandomAnonymiser`
 
@@ -796,12 +812,15 @@ the next time.
 
 ```python3
 RandomAnonymiser(
+    strict=True,
     random_source=RandomSource(
         random_int=random.randint,
         random_uuid=generate_random_uuid,
     )
 )
 ```
+
+`strict` is `True` by default for this anonymiser, but you can set it to `False` if you want that behaviour.
 
 Configuration for the `RandomSource` is the same as `ConsistentAnonymiser`.
 

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -754,11 +754,51 @@ You can see in this example that the amount of points gained from start to end f
 with the streamer usernames. Even the `Logs file` path is anonymised, keep this in mind since this should actually be
 in a file named with your real username.
 
-All the following anonymisers can optionally specify a boolean for the `strict` parameter. If this is set to `True` then
-all web API responses will be redacted. This is useful because we cannot guarantee that text the miner didn't create
-doesn't contain data that should be anonymised. You can optionally set it to `False` to allow logging these responses.
-This can be useful if it's not possible to debug an issue without checking the response text although it comes with more
-risk of leaking data that you might want anonymised.
+The `ConsistentAnonymiser` and `RandomAnonymiser` can optionally specify some configuration options for each type of
+anonymisation.
+
+**`channel_ids`**
+
+Can be set to `True` to enable anonymising channel ids, this includes your own user id (since users are also channels),
+as well as streamer channel ids. In addition, some Hermes WebSocket API ids include the channel id (Twitch may phase
+this out in future) so these also get anonymised. If `False` then channel ids will not be anonymised. Defaults to
+`True`.
+
+**`usernames`**
+
+Can be set to `True` to enable anonymising streamer usernames, this includes your own username. If `False` then 
+usernames will not be anonymised. Defaults to `True`.
+
+**`channel_points`**
+
+Can be set to `True` to enable anonymising streamer channel points. If `False` then channel points will not be
+anonymised. Defaults to `True`.
+
+**`strict`**
+
+If this is set to `True` then all web API responses will be redacted. This is useful because we cannot guarantee that
+text the miner didn't create doesn't contain data that should be anonymised. You can optionally set it to `False` to
+allow logging these responses. This can be useful if it's not possible to debug an issue without checking the response
+text, although it comes with more risk of leaking data that you might want anonymised.
+
+**`base_path`**
+
+This is the configuration option for filepath anonymisation. This is useful if you want to anonymise your local system
+user's name. You can set this to `True` to enable this feature, this is all you should need to do but advanced users may
+want to specify a `str` that represents the "base path" of files to be redacted. For example:
+
+```text
+If
+    `base_path` = "/home/username/miner"
+Then
+    "/home/username/miner/module_1/module_2/some_python_file.py"
+Becomes
+    "[PATH REDACTED]/module_1/module_2/some_python_file.py"
+```
+
+You can see how the `username` part of the filepath has been removed.
+
+This will apply to all paths logged as part of exception stack traces in `ERROR` logging.
 
 #### `ConsistentAnonymiser`
 
@@ -774,7 +814,11 @@ logged.
 
 ```python3
 ConsistentAnonymiser(
+    channel_ids=True,
+    usernames=True,
+    channel_points=True,
     strict=True,
+    base_path=True,
     random_points_min=100,
     random_points_max=1_000_000,
     random_source=RandomSource(
@@ -783,8 +827,6 @@ ConsistentAnonymiser(
     ),
 )
 ```
-
-`strict` is `True` by default for this anonymiser. It can be set to `False` if you want API responses to be logged.
 
 `random_points_min` to `random_points_max` defines the range of possible values when generating the initial random
 channel points for a Streamer. In this example, channel points will be in the range `100` to `1_000_000`.
@@ -812,7 +854,11 @@ the next time.
 
 ```python3
 RandomAnonymiser(
+    channel_ids=True,
+    usernames=True,
+    channel_points=True,
     strict=True,
+    base_path=True,
     random_source=RandomSource(
         random_int=random.randint,
         random_uuid=generate_random_uuid,

--- a/example.py
+++ b/example.py
@@ -3,6 +3,7 @@
 import logging
 from colorama import Fore
 from TwitchChannelPointsMiner import TwitchChannelPointsMiner
+from TwitchChannelPointsMiner.classes.Anonymiser import ConsistentAnonymiser
 from TwitchChannelPointsMiner.logger import LoggerSettings, ColorPalette
 from TwitchChannelPointsMiner.classes.Chat import ChatPresence
 from TwitchChannelPointsMiner.classes.Discord import Discord
@@ -93,7 +94,12 @@ twitch_miner = TwitchChannelPointsMiner(
                 events=[Events.BET_GENERAL, Events.BET_LOSE,
                         Events.BET_WIN, Events.BET_REFUND],
             )
-        ]                                                                             # Add any additional log hooks to this list, in this example 2 different discord webhooks get 2 different types of Events
+        ],                                                                            # Add any additional log hooks to this list, in this example 2 different discord webhooks get 2 different types of Events
+        redact_secrets=False,                                                         # Set to True to redact secrets like passwords or authentication tokens
+        anonymiser=ConsistentAnonymiser(                                              # Set this to an Anonymiser to anonymise channel usernames, ids, and points
+            random_points_min=100,                                                    # Optionally set this to set the per channel minimum for the random channel points
+            random_points_max=1_000_000                                               # Optionally set this to se the per channel maximum for the random channel points
+        ),
     ),
     streamer_settings=StreamerSettings(
         make_predictions=True,                  # If you want to Bet / Make prediction

--- a/tests/classes/test_anonymiser.py
+++ b/tests/classes/test_anonymiser.py
@@ -1,0 +1,182 @@
+from unittest.mock import MagicMock
+import pytest
+
+from TwitchChannelPointsMiner.classes.Anonymiser import (
+    Anonymiser, Deanonymiser, RandomAnonymiser, ConsistentAnonymiser,
+    IncrementingIdStore, RandomSource, IdStore, UUIDStore
+)
+from TwitchChannelPointsMiner.classes.entities.PubsubTopic import PubsubTopic
+from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer
+
+
+class MockAnonymiser(Anonymiser):
+    def __init__(self):
+        self.mock_channel_id = MagicMock()
+        self.mock_username = MagicMock()
+        self.mock_channel_points = MagicMock()
+        self.mock_hermes_subscription_id = MagicMock()
+
+    def channel_id(self, channel_id: str) -> str:
+        return self.mock_channel_id(channel_id)
+
+    def username(self, username: str) -> str:
+        return self.mock_username(username)
+
+    def channel_points(self, streamer: Streamer) -> int:
+        return self.mock_channel_points(streamer)
+
+    def hermes_subscription_id(self, _id: str) -> str:
+        return self.mock_hermes_subscription_id(_id)
+
+
+class TestAnonymiser:
+    test_topic_data = [
+        ["123.456", "456"],
+        [PubsubTopic("example-topic-v1", "01234"), "01234"],
+        [PubsubTopic("example-topic-v1", "01234", Streamer("StreamerUsername", channel_id="56789")), "56789"],
+    ]
+
+    @pytest.mark.parametrize("topic,expected_call_id", test_topic_data)
+    def test_topic(self, topic: str | PubsubTopic, expected_call_id: str):
+        anonymiser = MockAnonymiser()
+        anonymiser.topic(topic)
+        anonymiser.mock_channel_id.assert_called_once_with(expected_call_id)
+
+
+class TestDeanonymiser:
+    test_streamer_name_data = [
+        ["", ""],
+        ["a", "a"],
+        ["streamer", "streamer"],
+        ["username", "username"],
+    ]
+
+    @pytest.mark.parametrize("username,expected_name", test_streamer_name_data)
+    def test_streamer_name(self, username: str, expected_name: str) -> None:
+        anonymiser = Deanonymiser()
+        assert anonymiser.streamer_username(Streamer(username)) == expected_name
+
+    test_channel_points_data = [
+        [0, 0],
+        [1, 1],
+        [10, 10],
+        [1_000_000, 1_000_000],
+        [3458901, 3458901],
+    ]
+
+    @pytest.mark.parametrize("points,expected_points", test_channel_points_data)
+    def test_channel_points(self, points: int, expected_points: int) -> None:
+        anonymiser = Deanonymiser()
+        assert anonymiser.channel_points(Streamer("test", channel_points=points)) == expected_points
+
+
+class TestRandomAnonymiser:
+    def test_streamer_name(self):
+        names = ["Streamer 5", "Streamer 1", "Streamer 35", "Streamer 82", "Streamer 4"]
+        random_int = MagicMock()
+        random_int.side_effect = [5, 1, 35, 82, 4]
+        anonymiser = RandomAnonymiser(RandomSource(random_int))
+
+        for name in names:
+            assert anonymiser.streamer_username(Streamer(name)) == name
+
+    def test_channel_points(self):
+        points = [0, 123, 43_809, 233, 999]
+        random_int = MagicMock()
+        random_int.side_effect = points
+        anonymiser = RandomAnonymiser(RandomSource(random_int))
+
+        for point in points:
+            assert anonymiser.channel_points(Streamer("test")) == point
+
+
+class MockIdStore(IdStore[str]):
+    def __init__(self):
+        super().__init__()
+        self.mock_next_id = MagicMock()
+
+    def _next_id(self) -> str:
+        return self.mock_next_id()
+
+
+class TestIdStore:
+    def test_id(self):
+        id_store = MockIdStore()
+        id_store.id("test key")
+        id_store.mock_next_id.assert_called_once()
+
+
+class TestUUIDStore:
+    def test_id(self):
+        """ Tests that the ids are unique and consistent. """
+        store = UUIDStore()
+
+        ids = [
+            "streamer_a",
+            "streamer_b",
+            "streamer_c",
+            "streamer_d",
+            "streamer_e",
+        ]
+
+        anonymous_ids = set()
+
+        for _id in ids:
+            first_id = store.id(_id)
+            second_id = store.id(_id)
+            assert first_id == second_id
+            assert not first_id in anonymous_ids
+            anonymous_ids.add(first_id)
+
+
+class TestIncrementingIdStore:
+    def test_id(self):
+        """ Tests that the ids are unique and consistent. """
+        store = IncrementingIdStore()
+
+        ids = [
+            "streamer_a",
+            "streamer_b",
+            "streamer_c",
+            "streamer_d",
+            "streamer_e",
+        ]
+
+        anonymous_ids = set()
+
+        for _id in ids:
+            first_id = store.id(_id)
+            second_id = store.id(_id)
+            assert first_id == second_id
+            assert not first_id in anonymous_ids
+            anonymous_ids.add(first_id)
+
+
+class TestConsistentAnonymiser:
+    def test_streamer_id_empty_string(self):
+        anonymiser = ConsistentAnonymiser()
+        assert anonymiser.channel_id("") == ""
+
+    test_channel_points_data = [
+        [0, []],
+        [123, [10, 0, -50, 450, 10_000]],
+        [23_423, [-23_423, 10, 100]]
+    ]
+
+    @pytest.mark.parametrize("initial_points,deltas", test_channel_points_data)
+    def test_channel_points(self, initial_points: int, deltas: list[int]):
+        """ Tests that channel points are consistent and are correctly updated by a list of point deltas. """
+        random_int = MagicMock()
+        random_int.return_value = 1000
+
+        streamer = Streamer("test", channel_points=initial_points)
+
+        anonymiser = ConsistentAnonymiser(random_source=RandomSource(random_int))
+
+        assert anonymiser.channel_points(streamer) == 1000
+
+        current_expected_points = 1000
+        for delta in deltas:
+            streamer.channel_points += delta
+            current_expected_points += delta
+            assert anonymiser.channel_points(streamer) == current_expected_points

--- a/tests/classes/test_anonymiser.py
+++ b/tests/classes/test_anonymiser.py
@@ -10,8 +10,8 @@ from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer
 
 
 class MockAnonymiser(Anonymiser):
-    def __init__(self):
-        super().__init__(False)
+    def __init__(self, base_path: str | bool = True):
+        super().__init__(channel_ids=True, usernames=True, channel_points=True, strict=True, base_path=base_path)
         self.mock_channel_id = MagicMock()
         self.mock_username = MagicMock()
         self.mock_channel_points = MagicMock()
@@ -43,6 +43,21 @@ class TestAnonymiser:
         anonymiser.topic(topic)
         anonymiser.mock_channel_id.assert_called_once_with(expected_call_id)
 
+    test_redact_path_data = [
+        [True, "/filename.py", "[PATH REDACTED]/filename.py"],
+        [True, "filename.py", "filename.py"],
+        ["/base/path", "/base/path/file.py", "[PATH REDACTED]/file.py"],
+        ["/base/path", "/base/path/sub/path/filename.py", "[PATH REDACTED]/sub/path/filename.py"],
+        ["/base/path", "file.py", "file.py"],
+        ["/base/path", "/different/base/path/file.py", "[PATH REDACTED]/file.py"],
+        ["/base/path", "/different/base/path/sub/path/filename.py", "[PATH REDACTED]/filename.py"],
+    ]
+
+    @pytest.mark.parametrize("base_path,path,expected", test_redact_path_data)
+    def test_filepath(self, base_path: str, path: str, expected: str):
+        anonymiser = MockAnonymiser(base_path=base_path)
+        assert anonymiser.filepath(path) == expected
+
 
 class TestDeanonymiser:
     test_streamer_name_data = [
@@ -70,13 +85,22 @@ class TestDeanonymiser:
         anonymiser = Deanonymiser()
         assert anonymiser.channel_points(Streamer("test", channel_points=points)) == expected_points
 
+    def test_each(self):
+        anonymiser = Deanonymiser()
+        assert anonymiser.channel_id("564681") == "564681"
+        assert anonymiser.username("some_username") == "some_username"
+        assert anonymiser.channel_points(Streamer("test", channel_points=497364)) == 497364
+        assert anonymiser.hermes_subscription_id(
+            "c52180bd-9407-43cf-a180-bd940723cfa1"
+        ) == "c52180bd-9407-43cf-a180-bd940723cfa1"
+
 
 class TestRandomAnonymiser:
     def test_streamer_name(self):
         names = ["Streamer 5", "Streamer 1", "Streamer 35", "Streamer 82", "Streamer 4"]
         random_int = MagicMock()
         random_int.side_effect = [5, 1, 35, 82, 4]
-        anonymiser = RandomAnonymiser(False, RandomSource(random_int))
+        anonymiser = RandomAnonymiser(strict=False, random_source=RandomSource(random_int))
 
         for name in names:
             assert anonymiser.streamer_username(Streamer(name)) == name
@@ -85,10 +109,19 @@ class TestRandomAnonymiser:
         points = [0, 123, 43_809, 233, 999]
         random_int = MagicMock()
         random_int.side_effect = points
-        anonymiser = RandomAnonymiser(False, RandomSource(random_int))
+        anonymiser = RandomAnonymiser(strict=False, random_source=RandomSource(random_int))
 
         for point in points:
             assert anonymiser.channel_points(Streamer("test")) == point
+
+    def test_settings_false(self):
+        anonymiser = RandomAnonymiser(channel_ids=False, usernames=False, channel_points=False, strict=False)
+        assert anonymiser.channel_id("564681") == "564681"
+        assert anonymiser.username("some_username") == "some_username"
+        assert anonymiser.channel_points(Streamer("test", channel_points=497364)) == 497364
+        assert anonymiser.hermes_subscription_id(
+            "c52180bd-9407-43cf-a180-bd940723cfa1"
+        ) == "c52180bd-9407-43cf-a180-bd940723cfa1"
 
 
 class MockIdStore(IdStore[str]):
@@ -181,3 +214,12 @@ class TestConsistentAnonymiser:
             streamer.channel_points += delta
             current_expected_points += delta
             assert anonymiser.channel_points(streamer) == current_expected_points
+
+    def test_settings_false(self):
+        anonymiser = ConsistentAnonymiser(channel_ids=False, usernames=False, channel_points=False, strict=False)
+        assert anonymiser.channel_id("564681") == "564681"
+        assert anonymiser.username("some_username") == "some_username"
+        assert anonymiser.channel_points(Streamer("test", channel_points=497364)) == 497364
+        assert anonymiser.hermes_subscription_id(
+            "c52180bd-9407-43cf-a180-bd940723cfa1"
+        ) == "c52180bd-9407-43cf-a180-bd940723cfa1"

--- a/tests/classes/test_anonymiser.py
+++ b/tests/classes/test_anonymiser.py
@@ -11,6 +11,7 @@ from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer
 
 class MockAnonymiser(Anonymiser):
     def __init__(self):
+        super().__init__(False)
         self.mock_channel_id = MagicMock()
         self.mock_username = MagicMock()
         self.mock_channel_points = MagicMock()
@@ -75,7 +76,7 @@ class TestRandomAnonymiser:
         names = ["Streamer 5", "Streamer 1", "Streamer 35", "Streamer 82", "Streamer 4"]
         random_int = MagicMock()
         random_int.side_effect = [5, 1, 35, 82, 4]
-        anonymiser = RandomAnonymiser(RandomSource(random_int))
+        anonymiser = RandomAnonymiser(False, RandomSource(random_int))
 
         for name in names:
             assert anonymiser.streamer_username(Streamer(name)) == name
@@ -84,7 +85,7 @@ class TestRandomAnonymiser:
         points = [0, 123, 43_809, 233, 999]
         random_int = MagicMock()
         random_int.side_effect = points
-        anonymiser = RandomAnonymiser(RandomSource(random_int))
+        anonymiser = RandomAnonymiser(False, RandomSource(random_int))
 
         for point in points:
             assert anonymiser.channel_points(Streamer("test")) == point

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -6,8 +6,7 @@ import pytest
 
 from TwitchChannelPointsMiner.utils.Utils import (
     interruptible_repeating_task,
-    interruptible_sleep,
-    percentage,
+    interruptible_sleep, oxford_comma_list,
 )
 
 test_interruptible_sleep_uninterrupted_data = [
@@ -221,3 +220,17 @@ def test_interruptible_repeating_task_execute_twice():
     assert run.call_count == 11
     assert thread.is_alive() is False
     assert task.call_count == 2
+
+
+test_oxford_comma_list_data = [
+    [[], ""],
+    [["item 1"], "item 1"],
+    [["item 1", "item 2"], "item 1 and item 2"],
+    [["item 1", "item 2", "item 3"], "item 1, item 2, and item 3"],
+    [["item 1", "item 2", "item 3", "item 4"], "item 1, item 2, item 3, and item 4"],
+]
+
+
+@pytest.mark.parametrize("items,expected", test_oxford_comma_list_data)
+def test_oxford_comma_list(items: list[str], expected: str) -> None:
+    assert oxford_comma_list(items) == expected


### PR DESCRIPTION
# Description

An attempt to make it easier to share logs without leaking information that should be anonymised/redacted.

- Adds `Anonymiser` classes and configuration options that can be used to anonymise certain values in the miner logs (streamer ids/usernames, channel point values).
  - Credit to @0x8fv for their work on a [similar implementation](https://github.com/0x8fv/Twitch-Channel-Points-Miner/blob/940c98409e5821900752815cd9550ae5b750b597/TwitchChannelPointsMiner/privacy/anonymizer.go) in their go miner!
- Also adds a `redact_secrets` option which redacts secret token (passwords, auth tokens, etc...) values from logs when enabled.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added new unit tests and ran the miner locally using the anonymisers.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
