### PR TITLE
Reintegrates the old M3U8 playback simulation, now renamed to HLS.

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -2,8 +2,7 @@
 # https://www.apollographql.com/docs/
 # https://github.com/mauricew/twitch-graphql-api
 # Full list of available methods: https://azr.ivr.fi/schema/query.doc.html (a bit outdated)
-
-
+import datetime
 import logging
 import os
 import random
@@ -15,8 +14,8 @@ from pathlib import Path
 from secrets import choice, token_hex
 
 import requests
+import validators
 
-from TwitchChannelPointsMiner.classes.StreamerSelector import StreamerSelector
 from TwitchChannelPointsMiner.classes.ClientSession import ClientSession
 from TwitchChannelPointsMiner.classes.Exceptions import (
     StreamerDoesNotExistException,
@@ -27,10 +26,14 @@ from TwitchChannelPointsMiner.classes.Settings import (
     FollowersOrder,
     Settings,
 )
+from TwitchChannelPointsMiner.classes.StreamerSelector import StreamerSelector
 from TwitchChannelPointsMiner.classes.TwitchLogin import TwitchLogin
 from TwitchChannelPointsMiner.classes.entities.Campaign import Campaign
 from TwitchChannelPointsMiner.classes.entities.CommunityGoal import CommunityGoal
 from TwitchChannelPointsMiner.classes.entities.Drop import Drop
+from TwitchChannelPointsMiner.classes.entities.PlaybackAccessToken import (
+    PlaybackAccessToken,
+)
 from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer
 from TwitchChannelPointsMiner.classes.gql.Errors import RetryError
 from TwitchChannelPointsMiner.classes.gql.Integration import GQLFactory
@@ -136,7 +139,7 @@ class Twitch(object):
                         extra={
                             "emoji": ":rocket:",
                             "event": Events.get("WATCH_STREAK_PROGRESS"),
-                        }
+                        },
                     )
 
                 event_properties = {
@@ -149,8 +152,8 @@ class Twitch(object):
                 }
 
                 if (
-                        streamer.stream.game_name() is not None
-                        and streamer.stream.game_id() is not None
+                    streamer.stream.game_name() is not None
+                    and streamer.stream.game_id() is not None
                 ):
                     event_properties["game"] = streamer.stream.game_name()
                     event_properties["game_id"] = streamer.stream.game_id()
@@ -204,7 +207,9 @@ class Twitch(object):
                 self.client_session.login.get_user_id(), streamer.channel_id
             )
         except RetryError as e:
-            logger.error(f"Error getting stream info for {Settings.logger.anonymiser.streamer_username(streamer)}: {e}")
+            logger.error(
+                f"Error getting stream info for {Settings.logger.anonymiser.streamer_username(streamer)}: {e}"
+            )
             raise e
         if info_response.user.stream is None:
             # There is no stream data, so they're offline
@@ -214,7 +219,7 @@ class Twitch(object):
                 info_response.user,
                 is_live_response.user,
                 reward_list_response.channel.self.watch_streak_milestone,
-                chat_room_ban_status.status
+                chat_room_ban_status.status,
             )
 
     def check_streamer_online(self, streamer):
@@ -255,7 +260,9 @@ class Twitch(object):
             else:
                 return response.id
         except RetryError as e:
-            logger.error(f"Error getting channel id for {Settings.logger.anonymiser.username(streamer_username)}: {e}")
+            logger.error(
+                f"Error getting channel id for {Settings.logger.anonymiser.username(streamer_username)}: {e}"
+            )
             raise StreamerDoesNotExistException
 
     def get_followers(
@@ -381,13 +388,170 @@ class Twitch(object):
             logger.error(f"Error with update_client_version: {e}")
             return self.client_session.version
 
+    def get_or_update_playback_access_token(
+        self, streamer: Streamer
+    ) -> PlaybackAccessToken | None:
+        """
+        Gets a PlaybackAccessToken for the current Stream for the given Streamer. This may involve making a GQL
+        request for a new token if one doesn't exist or the current one has expired.
+
+        :param streamer: The Streamer for which to get the token.
+        :return: The token or None if one could not be obtained.
+        """
+        if (
+            streamer.stream.playback_access_token is None
+            or streamer.stream.playback_access_token.value.expires
+            <= datetime.datetime.now(datetime.UTC)
+        ):
+            try:
+                gql_token = self.gql.get_playback_access_token(streamer.username)
+                token = PlaybackAccessToken.from_gql(gql_token)
+                streamer.stream.playback_access_token = token
+                logger.debug(
+                    f"Obtained PlaybackAccessToken for {streamer.username}, expires {token.value.expires}"
+                )
+            except RetryError as e:
+                logger.error(
+                    f"Unable to get PlaybackAccessToken for {streamer.username}: {e}"
+                )
+                return None
+        return streamer.stream.playback_access_token
+
+    def get_hls_playlist_url(self, streamer: Streamer) -> str | None:
+        """
+        Gets the playlist URL for the current Stream for the given Streamer.
+
+        :param streamer: The Streamer for which to get the URL.
+        :return: The URL or None if one could not be obtained.
+        """
+        if streamer.stream.hls_url is not None:
+            return streamer.stream.hls_url
+
+        token = self.get_or_update_playback_access_token(streamer)
+        if token is None:
+            return None
+
+        # Construct the URL for the broadcast qualities
+        master_playlist_url = f"https://usher.ttvnw.net/api/channel/hls/{streamer.username}.m3u8?sig={token.signature}&token={token.raw_value}"
+
+        # Get list of video qualities from master playlist
+        logger.debug(f"Sending master playlist request for {streamer}")
+        master_playlist_response = requests.get(
+            master_playlist_url,
+            headers={"User-Agent": self.client_session.user_agent},
+            timeout=CLIENT_WATCH_SECONDS,
+        )
+        logger.debug(
+            f"Sent master playlist request for {streamer}, Status: {master_playlist_response.status_code}"
+        )
+
+        if master_playlist_response.status_code != 200:
+            logger.debug(
+                f"Unable to request master playlist for {streamer}, Status: {master_playlist_response.status_code}"
+            )
+            return None
+
+        broadcast_qualities_urls = master_playlist_response.text
+
+        # Just take the last line, which should be the latest URL for the lowest quality
+        lowest_quality_playlist_url = broadcast_qualities_urls.split("\n")[-1]
+        if not validators.url(lowest_quality_playlist_url):
+            logger.debug(
+                f"Unable to parse URL from master playlist response, URL: {lowest_quality_playlist_url}"
+            )
+            return None
+        streamer.stream.hls_url = lowest_quality_playlist_url
+        return lowest_quality_playlist_url
+
+    def simulate_hls_playback(self, streamer: Streamer) -> bool:
+        """
+        Simulates the HLS playback for the current Stream for the given Streamer by making a HEAD request to the latest
+        stream segment.
+
+        :param streamer: The Streamer for which to simulate playback.
+        :return: True if playback succeeded, False otherwise.
+        """
+        # Twitch serves Streams via HLS which is based on M3U8 playlists. To "play back" a part of a stream you can:
+        # 1. Make a request to the "usher" URL which returns the Master Playlist
+        # 2. Take the last URL from the Master Playlist which should be the Lowest Quality Stream Playlist
+        # 3. Make a request to the Lowest Quality Stream Playlist URL which returns the Segment Playlist
+        # 4. Take the last URL from the Segment Playlist which should be the URL of the lastest Stream Segment
+        # 5. Make a HEAD request to the Stream Segment URL
+        # Steps 1 and 2 should only need to be done once per Stream. The rest must be done once per play back attempt
+        # because the contents of the Lowest Quality Stream Playlist changes at least every 2 seconds.
+
+        # Get the segment playlist URL for the lowest quality stream option
+        stream_playlist_url = self.get_hls_playlist_url(streamer)
+        if stream_playlist_url is None:
+            return False
+
+        # Get list of segment URLs
+        logger.debug(f"Sending stream playlist request for {streamer}")
+        stream_playlist_response = requests.get(
+            stream_playlist_url,
+            headers={"User-Agent": self.client_session.user_agent},
+            timeout=CLIENT_WATCH_SECONDS,
+        )
+        logger.debug(
+            f"Sent stream playlist request for {streamer}, Status: {stream_playlist_response.status_code}"
+        )
+
+        if stream_playlist_response.status_code != 200:
+            logger.debug(
+                f"Unable to get stream playlist, Status: {stream_playlist_response.status_code}"
+            )
+            return False
+        stream_playlist_text = stream_playlist_response.text
+
+        # Just take the last line, which should be the URL for the latest segment
+        stream_segment_url = stream_playlist_text.split("\n")[-2]
+        if not validators.url(stream_segment_url):
+            logger.debug(
+                f"Unable to parse latest segment URL from stream playlist, URL: {stream_segment_url}"
+            )
+            return False
+
+        # Perform a HEAD request to simulate watching the stream segment
+        logger.debug(f"Sending stream segment request for {streamer}")
+        stream_segment_response = requests.head(
+            stream_segment_url,
+            headers={"User-Agent": self.client_session.user_agent},
+            timeout=CLIENT_WATCH_SECONDS,
+        )
+        logger.debug(
+            f"Sent stream segment request for {streamer}, Status: {stream_segment_response.status_code}"
+        )
+        return stream_segment_response.status_code == 200
+
+    def send_spade_minute_watched_event(self, streamer: Streamer) -> bool:
+        """
+        Sends a minute watched event to the tracking endpoint for the current Stream for the given Streamer.
+
+        :param streamer: The Streamer for which to send the event.
+        :return: True if the request was successful, False otherwise.
+        """
+        logger.debug(f"Sending spade minute watched request for {streamer}")
+        response = requests.post(
+            streamer.stream.spade_url,  # pyright: ignore [reportArgumentType]
+            data=streamer.stream.encode_payload(),
+            headers={"User-Agent": self.client_session.user_agent},
+            timeout=CLIENT_WATCH_SECONDS,
+        )
+        logger.debug(
+            f"Sent spade minute watched request for {streamer} - Status code: {response.status_code}"
+        )
+
+        if response.status_code != 204:
+            logger.error(f"Unable to send spade minute watched request for {streamer}")
+            return False
+        return True
+
     def send_minute_watched_events(
         self,
         streamers: list[Streamer],
         streamer_selector: StreamerSelector,
         chunk_size=3,
     ):
-
         def find_streamer(channel_id: str) -> Streamer:
             for streamer in streamers:
                 if streamer.channel_id == channel_id:
@@ -417,7 +581,9 @@ class Twitch(object):
                         self.check_streamer_online(streamer)
 
                 selected_streamer_ids = streamer_selector.select(online_streamers, 2)
-                streamers_watching = [find_streamer(streamer_id) for streamer_id in selected_streamer_ids]
+                streamers_watching = [
+                    find_streamer(streamer_id) for streamer_id in selected_streamer_ids
+                ]
 
                 watch_attempts_start_time = time.time()
 
@@ -427,16 +593,13 @@ class Twitch(object):
                     )
 
                     try:
-                        response = requests.post(
-                            streamer.stream.spade_url,  # pyright: ignore [reportArgumentType]
-                            data=streamer.stream.encode_payload(),
-                            headers={"User-Agent": self.client_session.user_agent},
-                            timeout=CLIENT_WATCH_SECONDS,
-                        )
-                        logger.debug(
-                            f"Send minute watched request for {streamer} - Status code: {response.status_code}"
-                        )
-                        if response.status_code == 204:
+                        if (
+                            streamer.settings.simulate_hls_playback
+                            and not self.simulate_hls_playback(streamer)
+                        ):
+                            continue
+
+                        if self.send_spade_minute_watched_event(streamer):
                             streamer.stream.update_minute_watched()
 
                             """
@@ -468,14 +631,16 @@ class Twitch(object):
                                                     "skip_webhook": True,
                                                     "skip_matrix": True,
                                                     "skip_gotify": True,
-                                                    "skip_pushover": True
+                                                    "skip_pushover": True,
                                                 },
                                             )
 
                                         if len(Settings.logger.hooks) > 0:
                                             combined_message = "\n".join(drop_messages)
                                             for hook in Settings.logger.hooks:
-                                                hook.send(combined_message, Events.DROP_STATUS)
+                                                hook.send(
+                                                    combined_message, Events.DROP_STATUS
+                                                )
 
                     except requests.exceptions.ConnectionError as e:
                         logger.error(f"Error while trying to send minute watched: {e}")
@@ -488,12 +653,13 @@ class Twitch(object):
                     )
 
                 # Ensure we sleep at least 20 seconds, even if we `continue` iteration(s)
-                time_remaining = CLIENT_WATCH_SECONDS - (time.time() - watch_attempts_start_time)
+                time_remaining = CLIENT_WATCH_SECONDS - (
+                    time.time() - watch_attempts_start_time
+                )
                 if len(streamers_watching) == 0 or time_remaining > 0.01:
                     self.__chuncked_sleep(time_remaining, chunk_size=chunk_size)
             except Exception:
-                logger.error(
-                    "Exception raised in send minute watched", exc_info=True)
+                logger.error("Exception raised in send minute watched", exc_info=True)
                 # Do a short sleep to avoid error log spam
                 time.sleep(1)
 
@@ -525,7 +691,9 @@ class Twitch(object):
         if streamer.settings.community_goals is True:
             self.contribute_to_community_goals(streamer)
 
-    def initialize_streamers_context(self, streamers: list[Streamer], max_workers=10) -> set[str]:
+    def initialize_streamers_context(
+        self, streamers: list[Streamer], max_workers=10
+    ) -> set[str]:
         """
         Initializes the context for the given Streamers. Loads the channel points context and checks if they're online.
         Parallelizes execution across the given number of worker threads.

--- a/TwitchChannelPointsMiner/classes/entities/PlaybackAccessToken.py
+++ b/TwitchChannelPointsMiner/classes/entities/PlaybackAccessToken.py
@@ -1,0 +1,56 @@
+import datetime
+import json
+
+from TwitchChannelPointsMiner.classes.Settings import Settings
+from TwitchChannelPointsMiner.classes.gql.data.response.PlaybackAccessToken import (
+    PlaybackAccessTokenResponse as GQLPlaybackAccessToken,
+)
+
+
+class PlaybackAccessToken:
+    """Twitch Playback Access Token which can be used to request stream media."""
+
+    class Value:
+        """Decoded token payload."""
+
+        def __init__(self, expires: datetime.datetime):
+            self.expires = expires
+            """The expiry datetime of the token."""
+
+    def __init__(self, raw_value: str, signature: str, value: Value):
+        self.raw_value = raw_value
+        """The raw token value. This can be used as is to request stream media."""
+        self.signature = signature
+        """The token's signature."""
+        self.value = value
+        """The decoded token value."""
+
+    def __repr__(self) -> str:
+        if Settings.logger.less:
+            return f"PlaybackAccessToken(signature={self.signature}, expires={self.value.expires})"
+        else:
+            return f"PlaybackAccessToken(signature={self.signature}, expires={self.value.expires}, raw_value={self.raw_value})"
+
+    @staticmethod
+    def from_gql(token: GQLPlaybackAccessToken):
+        """
+        Decodes a PlaybackAccessToken from the equivalent GQL object.
+
+        :param token: The GQL token.
+        :return: The decoded token.
+        :raises ValueError: If the token cannot be decoded.
+        """
+        decoded_value = json.loads(token.value)
+        if "expires" not in decoded_value:
+            raise ValueError("PlaybackAccessToken value did not contain 'expires'")
+        expires = decoded_value["expires"]
+        if not isinstance(expires, int):
+            raise ValueError(
+                f"PlaybackAccessToken's value's 'expires' was not an int (was {type(expires).__name__})"
+            )
+        value = PlaybackAccessToken.Value(
+            expires=datetime.datetime.fromtimestamp(expires, tz=datetime.UTC)
+        )
+        return PlaybackAccessToken(
+            raw_value=token.value, signature=token.signature, value=value
+        )

--- a/TwitchChannelPointsMiner/classes/entities/Stream.py
+++ b/TwitchChannelPointsMiner/classes/entities/Stream.py
@@ -6,6 +6,9 @@ from datetime import datetime
 
 from TwitchChannelPointsMiner.classes.Settings import Settings
 from TwitchChannelPointsMiner.classes.entities.Campaign import Campaign
+from TwitchChannelPointsMiner.classes.entities.PlaybackAccessToken import (
+    PlaybackAccessToken,
+)
 from TwitchChannelPointsMiner.classes.gql import Tag
 from TwitchChannelPointsMiner.classes.gql.data.response.BroadcastSettings import (
     GameBroadcastSettings,
@@ -30,6 +33,8 @@ class Stream(object):
         "viewers_count",
         "spade_url",
         "payload",
+        "playback_access_token",
+        "hls_url",
         "watch_streak_missing",
         "minute_watched",
         "watch_count",
@@ -54,6 +59,10 @@ class Stream(object):
 
         self.spade_url: str | None = None
         self.payload = None
+        self.playback_access_token: PlaybackAccessToken | None = None
+        """A token that allows accessing stream media for this Stream."""
+        self.hls_url: str | None = None
+        """The URL of the HLS stream playlist for this Stream."""
 
         self.created_at: datetime | None = None
 
@@ -74,8 +83,10 @@ class Stream(object):
         watch_streak_milestone: WatchStreakMilestone | None,
     ):
         if self.broadcast_id != broadcast_id:
-            # Different stream, reset watch time
+            # Different stream, reset state
             self.init_watch_streak()
+            self.playback_access_token = None
+            self.hls_url = None
 
         self.broadcast_id = broadcast_id
         self.title = title.strip()

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -6,9 +6,9 @@ from datetime import datetime
 from threading import Lock
 
 from TwitchChannelPointsMiner.classes.Chat import ChatPresence, ThreadChat
+from TwitchChannelPointsMiner.classes.Settings import Events, Settings, StreamerSource
 from TwitchChannelPointsMiner.classes.entities.Bet import BetSettings, DelayMode
 from TwitchChannelPointsMiner.classes.entities.Stream import Stream
-from TwitchChannelPointsMiner.classes.Settings import Events, Settings, StreamerSource
 from TwitchChannelPointsMiner.classes.gql import Properties
 from TwitchChannelPointsMiner.constants import URL
 from TwitchChannelPointsMiner.utils import millify
@@ -27,6 +27,7 @@ class StreamerSettings(object):
         "community_goals",
         "bet",
         "chat",
+        "simulate_hls_playback",
     ]
 
     def __init__(
@@ -39,6 +40,7 @@ class StreamerSettings(object):
         community_goals: bool = None,
         bet: BetSettings = None,
         chat: ChatPresence = None,
+        simulate_hls_playback: bool = None,
     ):
         self.make_predictions = make_predictions
         self.follow_raid = follow_raid
@@ -48,6 +50,8 @@ class StreamerSettings(object):
         self.community_goals = community_goals
         self.bet = bet
         self.chat = chat
+        self.simulate_hls_playback = simulate_hls_playback
+        """If True, simulates playback of the stream via HLS when selected to watch."""
 
     def default(self):
         for name in [
@@ -56,6 +60,7 @@ class StreamerSettings(object):
             "claim_drops",
             "claim_moments",
             "watch_streak",
+            "simulate_hls_playback",
         ]:
             if getattr(self, name) is None:
                 setattr(self, name, True)
@@ -67,7 +72,7 @@ class StreamerSettings(object):
             self.chat = ChatPresence.ONLINE
 
     def __repr__(self):
-        return f"BetSettings(make_predictions={self.make_predictions}, follow_raid={self.follow_raid}, claim_drops={self.claim_drops}, claim_moments={self.claim_moments}, watch_streak={self.watch_streak}, community_goals={self.community_goals}, bet={self.bet}, chat={self.chat})"
+        return f"BetSettings(make_predictions={self.make_predictions}, follow_raid={self.follow_raid}, claim_drops={self.claim_drops}, claim_moments={self.claim_moments}, watch_streak={self.watch_streak}, community_goals={self.community_goals}, bet={self.bet}, chat={self.chat}, simulate_m3u8={self.simulate_m3u8})"
 
 
 class Streamer(object):

--- a/TwitchChannelPointsMiner/classes/gql/Integration.py
+++ b/TwitchChannelPointsMiner/classes/gql/Integration.py
@@ -1,7 +1,5 @@
 import copy
 import logging
-import sys
-import traceback
 from secrets import token_hex
 from typing import Callable, Any, Protocol
 
@@ -86,7 +84,9 @@ def error_context(e: Exception) -> str | None:
     :return: The context string, or None if no context is needed.
     """
     if not isinstance(e, GQLError):
-        return Settings.logger.anonymiser.format_exception((type(e), e, e.__traceback__))
+        return Settings.logger.anonymiser.format_exception(
+            (type(e), e, e.__traceback__)
+        )
     else:
         return None
 
@@ -191,19 +191,35 @@ class GQL:
                     # Annoyingly "channelLogin" is both a username and a channel id in different operations
                     if operation_name in [
                         GQLOperations.ChannelPointsContext["operationName"],
-                        GQLOperations.UserPointsContribution["operationName"]
+                        GQLOperations.UserPointsContribution["operationName"],
                     ]:
-                        variables["channelLogin"] = Settings.logger.anonymiser.username(channel_login)
-                    elif operation_name == GQLOperations.DropCampaignDetails["operationName"]:
-                        variables["channelLogin"] = Settings.logger.anonymiser.channel_id(channel_login)
+                        variables["channelLogin"] = Settings.logger.anonymiser.username(
+                            channel_login
+                        )
+                    elif (
+                        operation_name
+                        == GQLOperations.DropCampaignDetails["operationName"]
+                    ):
+                        variables["channelLogin"] = (
+                            Settings.logger.anonymiser.channel_id(channel_login)
+                        )
                 channel_id = variables.get("channelID", None)
                 if channel_id is not None:
-                    variables["channelID"] = Settings.logger.anonymiser.channel_id(channel_id)
-                if operation_name == GQLOperations.WithIsStreamLiveQuery["operationName"]:
-                    variables["id"] = Settings.logger.anonymiser.channel_id(variables["id"])
+                    variables["channelID"] = Settings.logger.anonymiser.channel_id(
+                        channel_id
+                    )
+                if (
+                    operation_name
+                    == GQLOperations.WithIsStreamLiveQuery["operationName"]
+                ):
+                    variables["id"] = Settings.logger.anonymiser.channel_id(
+                        variables["id"]
+                    )
                 target_user_id = variables.get("targetUserID", None)
                 if target_user_id is not None:
-                    variables["targetUserID"] = Settings.logger.anonymiser.channel_id(target_user_id)
+                    variables["targetUserID"] = Settings.logger.anonymiser.channel_id(
+                        target_user_id
+                    )
             return value
 
         if isinstance(json, dict):
@@ -230,7 +246,9 @@ class GQL:
 
         redacted_request_json = self.__redact_request_json(request_json)
 
-        response_text = "REDACTED" if Settings.logger.anonymiser.strict else response.text
+        response_text = (
+            "REDACTED" if Settings.logger.anonymiser.strict else response.text
+        )
 
         logger.debug(
             f"Data: {redacted_request_json}, Status code: {response.status_code}, Content: {response_text}"
@@ -440,6 +458,7 @@ class GQL:
             "isVod": False,
             "vodID": "",
             "playerType": "site",
+            "platform": "web",
         }
         return self.post_gql_request_single(
             GQLOperations.PlaybackAccessToken["operationName"],


### PR DESCRIPTION
# Description

Reintegrates the old M3U8 playback simulation, now renamed to HLS (HTTP Live Streaming). It should be noted that, while the integration is very similar to the old implementation, we now cache the `PlaybackAccessToken` and HLS Playlist URL to avoid making as many requests as possible.

Adds a configuration option to enable HLS playback simulation per Streamer.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested running live for a couple of days.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
