### PR TITLE
Points Limit

### DIFF
--- a/TwitchChannelPointsMiner/classes/StreamerSelector.py
+++ b/TwitchChannelPointsMiner/classes/StreamerSelector.py
@@ -26,8 +26,24 @@ class StreamerSelector(abc.ABC):
         pass
 
 
+def under_points_limit(streamer: Streamer):
+    """
+    Returns whether the Streamer has fewer channel points than its points limit. Returns `True` if there is no limit.
+
+    :param streamer: The Streamer to check.
+    :return: `True` if there is no points limit or the Streamer has fewer points than it, `False` otherwise.
+    """
+    return (
+        streamer.settings.points_limit is False
+        or streamer.channel_points <= streamer.settings.points_limit
+    )
+
+
 def priority_order(streamers: Sequence[Streamer], max_amount: int) -> list[str]:
-    return [streamer.channel_id for streamer in streamers[:max_amount]]
+    return [
+        streamer.channel_id
+        for streamer in islice(filter(under_points_limit, streamers), max_amount)
+    ]
 
 
 def priority_points(
@@ -36,6 +52,7 @@ def priority_points(
     items = [
         {"points": streamer.channel_points, "id": streamer.channel_id}
         for streamer in streamers
+        if under_points_limit(streamer)
     ]
     items = sorted(
         items,
@@ -45,11 +62,15 @@ def priority_points(
     return [item["id"] for item in items][:max_amount]
 
 
-def priority_points_ascending(streamers: Sequence[Streamer], max_amount: int) -> list[str]:
+def priority_points_ascending(
+    streamers: Sequence[Streamer], max_amount: int
+) -> list[str]:
     return priority_points(streamers, max_amount, False)
 
 
-def priority_points_descending(streamers: Sequence[Streamer], max_amount: int) -> list[str]:
+def priority_points_descending(
+    streamers: Sequence[Streamer], max_amount: int
+) -> list[str]:
     return priority_points(streamers, max_amount, True)
 
 
@@ -59,12 +80,12 @@ def priority_streak(streamers: Sequence[Streamer], max_amount: int) -> list[str]
         if len(result) >= max_amount:
             break
         if (
-                streamer.settings.watch_streak is True
-                and streamer.stream.watch_streak_missing is True
-                and (
+            streamer.settings.watch_streak is True
+            and streamer.stream.watch_streak_missing is True
+            and (
                 streamer.offline_at == 0
                 or ((time.time() - streamer.offline_at) // 60) > 30
-        )
+            )
         ):
             result.append(streamer.channel_id)
     return result
@@ -80,7 +101,9 @@ def priority_drops(streamers: Sequence[Streamer], max_amount: int) -> list[str]:
 
 def priority_subscribed(streamers: Sequence[Streamer], max_amount: int) -> list[str]:
     streamers_with_multiplier = [
-        streamer for streamer in streamers if streamer.viewer_has_points_multiplier()
+        streamer
+        for streamer in streamers
+        if under_points_limit(streamer) and streamer.viewer_has_points_multiplier()
     ]
     streamers_with_multiplier = sorted(
         streamers_with_multiplier,
@@ -105,7 +128,7 @@ def priority_watch(streamers: Sequence[Streamer], max_amount: int) -> list[str]:
                 streamer.channel_id
                 for streamer in streamers
                 if streamer.stream.watch_session_state is not None
-                   and (
+                and (
                     (
                         datetime.datetime.now(datetime.timezone.utc)
                         - streamer.stream.watch_session_state
@@ -159,7 +182,11 @@ class PrioritySelector(StreamerSelector):
         priorities: list[Priority] | None = None,
         priority_function_overrides: dict[Priority, PriorityFunction] | None = None,
     ):
-        self.priorities = priorities if priorities is not None else [Priority.STREAK, Priority.DROPS, Priority.ORDER]
+        self.priorities = (
+            priorities
+            if priorities is not None
+            else [Priority.STREAK, Priority.DROPS, Priority.ORDER]
+        )
         if priority_function_overrides is not None:
             self.priority_functions = {
                 priority: priority_function_overrides.get(
@@ -203,7 +230,9 @@ def all_filter(streamers: Sequence[Streamer]) -> Sequence[Streamer]:
     return streamers
 
 
-def in_list_filter(filter_streamers: list[str]) -> Callable[[Sequence[Streamer]], Sequence[Streamer]]:
+def in_list_filter(
+    filter_streamers: list[str],
+) -> Callable[[Sequence[Streamer]], Sequence[Streamer]]:
     """
     Returns a filter function that filters out any streamers that aren't in the given list (based on usernames).
 
@@ -222,7 +251,9 @@ def in_list_filter(filter_streamers: list[str]) -> Callable[[Sequence[Streamer]]
     return sub_filter
 
 
-def from_source_filter(filter_source: StreamerSource) -> Callable[[Sequence[Streamer]], Sequence[Streamer]]:
+def from_source_filter(
+    filter_source: StreamerSource,
+) -> Callable[[Sequence[Streamer]], Sequence[Streamer]]:
     """
     Returns a filter function that filters out any streamers that aren't sourced in the given way.
 
@@ -230,13 +261,13 @@ def from_source_filter(filter_source: StreamerSource) -> Callable[[Sequence[Stre
     :return: The filter function.
     """
     return lambda streamers: [
-        streamer
-        for streamer in streamers
-        if streamer.source == filter_source
+        streamer for streamer in streamers if streamer.source == filter_source
     ]
 
 
-def arbitrary_filter(filter_function: Callable[[Streamer], bool]) -> Callable[[Sequence[Streamer]], Sequence[Streamer]]:
+def arbitrary_filter(
+    filter_function: Callable[[Streamer], bool],
+) -> Callable[[Sequence[Streamer]], Sequence[Streamer]]:
     """
     Filters out any streamers that don't return `True` for the given function.
 
@@ -244,9 +275,7 @@ def arbitrary_filter(filter_function: Callable[[Streamer], bool]) -> Callable[[S
     :return: The filter function.
     """
     return lambda streamers: [
-        streamer
-        for streamer in streamers
-        if filter_function(streamer)
+        streamer for streamer in streamers if filter_function(streamer)
     ]
 
 
@@ -254,7 +283,9 @@ class PriorityGroupSelector(StreamerSelector):
     """Selects streamers based on the given streamers filter."""
 
     def __init__(
-        self, streamers: list[str] | StreamerSource | Callable[[Streamer], bool] | None, selector: PrioritySelector
+        self,
+        streamers: list[str] | StreamerSource | Callable[[Streamer], bool] | None,
+        selector: PrioritySelector,
     ) -> None:
         self.streamers = streamers
         """
@@ -288,7 +319,9 @@ class PriorityGroupSelector(StreamerSelector):
                 # Use all streamers if list is empty
                 self._filter = all_filter
         else:
-            raise TypeError("Streamers must be one of list[str], StreamerSource, Callable, or None")
+            raise TypeError(
+                "Streamers must be one of list[str], StreamerSource, Callable, or None"
+            )
 
     def select(self, streamers: Sequence[Streamer], max_amount: int) -> list[str]:
         sub_streamers = self._filter(streamers)

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -43,6 +43,7 @@ class StreamerSettings(object):
         "chat",
         "simulate_hls_playback",
         "weekly_rewards",
+        "points_limit",
     ]
 
     def __init__(
@@ -57,6 +58,7 @@ class StreamerSettings(object):
         chat: ChatPresence = None,
         simulate_hls_playback: Literal[False] | HLSSettings | None = None,
         weekly_rewards: bool | None = None,
+        points_limit: int | Literal[False] | None = None,
     ):
         self.make_predictions = make_predictions
         self.follow_raid = follow_raid
@@ -72,6 +74,7 @@ class StreamerSettings(object):
         If False, the miner won't perform HLS simulation.
         """
         self.weekly_rewards = weekly_rewards
+        self.points_limit = points_limit
 
     def default(self):
         for name in [
@@ -92,6 +95,8 @@ class StreamerSettings(object):
             self.chat = ChatPresence.ONLINE
         if self.simulate_hls_playback is None:
             self.simulate_hls_playback = HLSSettings(refresh_before=2 * 60)
+        if self.points_limit is None:
+            self.points_limit = False
 
     def __repr__(self):
         return f"StreamerSettings(make_predictions={self.make_predictions}, follow_raid={self.follow_raid}, claim_drops={self.claim_drops}, claim_moments={self.claim_moments}, watch_streak={self.watch_streak}, community_goals={self.community_goals}, bet={self.bet}, chat={self.chat}, simulate_hls_playback={self.simulate_hls_playback}, weekly_rewards={self.weekly_rewards})"

--- a/docs/guides/advanced-configuration.md
+++ b/docs/guides/advanced-configuration.md
@@ -751,6 +751,17 @@ In this example, I've set the number of seconds to `5 * 60` or 5 minutes. This w
 once we get to 5 minutes before the token expires. Tokens typically last for 20 minutes. The default is 120 seconds (2
 minutes).
 
+#### `weekly_rewards`
+
+Enables automatic progression of Weekly Rewards for this streamer. This includes both selecting them when using
+`Priority.WEEKLY_REWARDS` and automatic progression when the streamer is offline. Defaults to `True`.
+
+#### 'points_limit'
+
+Set this to a whole positive number (e.g. `1000`, `50000`) to enable a limit on the amount of points that the miner will
+attempt to get for this Streamer. This only applies to `Priority.ORDER`, `Priority.POINTS_ASCENDING`,
+`Priority.POINTS_DESCENDING`, and `Priority.SUBSCRIBED`. Set this to `None` or `False` to disable.
+
 
 #### `bet`
 

--- a/example.py
+++ b/example.py
@@ -113,6 +113,8 @@ twitch_miner = TwitchChannelPointsMiner(
         simulate_hls_playback=HLSSettings(      # Set to False to disable HLS playback.
             refresh_before=120,                 # Set to the number of seconds before expiry to refresh the PlaybackAccessToken.
         ),
+        weekly_rewards=True,                    # Automatically progress Weekly Rewards
+        points_limit=50000,                     # The limit on the number of points the miner will attempt to mine for the` Streamer
         bet=BetSettings(
             strategy=Strategy.SMART,            # Choose you strategy!
             percentage=5,                       # Place the x% of your channel points

--- a/tests/classes/test_streamer_selector.py
+++ b/tests/classes/test_streamer_selector.py
@@ -1,7 +1,7 @@
 import datetime
 import time
-from typing import Sequence, Callable
-from unittest.mock import MagicMock
+from typing import Iterable, Sequence, Callable
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,6 +18,7 @@ from TwitchChannelPointsMiner.classes.StreamerSelector import (
     NestedSelector,
     StreamerSelector,
     priority_streak_by_earliest_stream_created_at,
+    under_points_limit,
 )
 from TwitchChannelPointsMiner.classes.entities.Stream import Stream
 from TwitchChannelPointsMiner.classes.entities.Streamer import (
@@ -25,6 +26,114 @@ from TwitchChannelPointsMiner.classes.entities.Streamer import (
     StreamerSettings,
 )
 from TwitchChannelPointsMiner.classes.gql import Properties
+
+
+def init_settings(streamers: Iterable[Streamer]):
+    # Initialise settings points_limit where it hasn't been set
+    for streamer in streamers:
+        if streamer.settings is None:
+            streamer.settings = StreamerSettings(points_limit=False)
+
+
+test_under_points_limit_data = [
+    (
+        Streamer(
+            "1", "a", channel_points=0, settings=StreamerSettings(points_limit=False)
+        ),
+        True,
+    ),
+    (
+        Streamer(
+            "1",
+            "a",
+            channel_points=1_000_000,
+            settings=StreamerSettings(points_limit=False),
+        ),
+        True,
+    ),
+    (
+        Streamer("1", "a", channel_points=0, settings=StreamerSettings(points_limit=0)),
+        True,
+    ),
+    (
+        Streamer(
+            "1",
+            "a",
+            channel_points=1,
+            settings=StreamerSettings(points_limit=0),
+        ),
+        False,
+    ),
+    (
+        Streamer(
+            "1",
+            "a",
+            channel_points=100,
+            settings=StreamerSettings(points_limit=0),
+        ),
+        False,
+    ),
+    (
+        Streamer(
+            "1",
+            "a",
+            channel_points=1000,
+            settings=StreamerSettings(points_limit=500),
+        ),
+        False,
+    ),
+    (
+        Streamer(
+            "1",
+            "a",
+            channel_points=100,
+            settings=StreamerSettings(points_limit=1000),
+        ),
+        True,
+    ),
+    (
+        Streamer(
+            "1",
+            "a",
+            channel_points=999,
+            settings=StreamerSettings(points_limit=1000),
+        ),
+        True,
+    ),
+    (
+        Streamer(
+            "1",
+            "a",
+            channel_points=1000,
+            settings=StreamerSettings(points_limit=1000),
+        ),
+        True,
+    ),
+    (
+        Streamer(
+            "1",
+            "a",
+            channel_points=1001,
+            settings=StreamerSettings(points_limit=1000),
+        ),
+        False,
+    ),
+    (
+        Streamer(
+            "1",
+            "a",
+            channel_points=10000,
+            settings=StreamerSettings(points_limit=1000),
+        ),
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize("streamer,expected", test_under_points_limit_data)
+def test_under_points_limit(streamer: Streamer, expected: bool):
+    assert under_points_limit(streamer) == expected
+
 
 priority_order_data = [
     [[], 0, []],
@@ -44,8 +153,16 @@ priority_order_data = [
 def test_priority_order(
     streamers: list[Streamer], max_amount: int, expected_ids: list[str]
 ):
-    streamer_ids = priority_order(streamers, max_amount)
-    assert streamer_ids == expected_ids
+    init_settings(streamers)
+    expected_calls = min(max_amount, len(streamers))
+    with patch(
+        "TwitchChannelPointsMiner.classes.StreamerSelector.under_points_limit"
+    ) as under_points_limit_mock:
+        streamer_ids = priority_order(streamers, max_amount)
+        assert (
+            under_points_limit_mock.call_count == expected_calls
+        ), f"under_points_limit should be called {expected_calls} time(s) (min({max_amount}, {len(streamers)}))"
+        assert streamer_ids == expected_ids
 
 
 priority_points_ascending_data = [
@@ -102,8 +219,16 @@ priority_points_ascending_data = [
 def test_priority_points_ascending(
     streamers: list[Streamer], max_amount: int, expected_ids: list[str]
 ):
-    streamer_ids = priority_points_ascending(streamers, max_amount)
-    assert streamer_ids == expected_ids
+    init_settings(streamers)
+    expected_calls = len(streamers)
+    with patch(
+        "TwitchChannelPointsMiner.classes.StreamerSelector.under_points_limit"
+    ) as under_points_limit_mock:
+        streamer_ids = priority_points_ascending(streamers, max_amount)
+        assert (
+            under_points_limit_mock.call_count == expected_calls
+        ), f"under_points_limit should be called {expected_calls} time(s)"
+        assert streamer_ids == expected_ids
 
 
 priority_points_descending_data = [
@@ -160,8 +285,16 @@ priority_points_descending_data = [
 def test_priority_points_descending(
     streamers: list[Streamer], max_amount: int, expected_ids: list[str]
 ):
-    streamer_ids = priority_points_descending(streamers, max_amount)
-    assert streamer_ids == expected_ids
+    init_settings(streamers)
+    expected_calls = len(streamers)
+    with patch(
+        "TwitchChannelPointsMiner.classes.StreamerSelector.under_points_limit"
+    ) as under_points_limit_mock:
+        streamer_ids = priority_points_descending(streamers, max_amount)
+        assert (
+            under_points_limit_mock.call_count == expected_calls
+        ), f"under_points_limit should be called {expected_calls} time(s)"
+        assert streamer_ids == expected_ids
 
 
 settings_watch_streak_true = StreamerSettings(watch_streak=True)
@@ -600,8 +733,16 @@ priority_subscribed_data = [
 def test_priority_subscribed(
     streamers: list[Streamer], max_amount: int, expected_ids: list[str]
 ):
-    streamer_ids = priority_subscribed(streamers, max_amount)
-    assert streamer_ids == expected_ids
+    init_settings(streamers)
+    expected_calls = len(streamers)
+    with patch(
+        "TwitchChannelPointsMiner.classes.StreamerSelector.under_points_limit"
+    ) as under_points_limit_mock:
+        streamer_ids = priority_subscribed(streamers, max_amount)
+        assert (
+            under_points_limit_mock.call_count == expected_calls
+        ), f"under_points_limit should be called {expected_calls} time(s)"
+        assert streamer_ids == expected_ids
 
 
 def priority_selects_none(streamers: Sequence[Streamer], max_amount: int) -> list[str]:
@@ -691,8 +832,10 @@ class TestPrioritySelector:
         assert set(streamer_ids) == set(expected_ids)
 
     def test_priority_selector_order_unchanged(self):
-        streamers = [Streamer("2", "b", settings=settings_watch_streak_true),
-                     Streamer("1", "a", settings=settings_watch_streak_true)]
+        streamers = [
+            Streamer("2", "b", settings=settings_watch_streak_true),
+            Streamer("1", "a", settings=settings_watch_streak_true),
+        ]
         selector = PrioritySelector(
             [Priority.STREAK, Priority.DROPS, Priority.SUBSCRIBED, Priority.ORDER],
         )
@@ -772,28 +915,28 @@ class TestPriorityGroupSelector:
             0,
             StreamerSource.Streamers,
             [streamer_a, streamer_c],
-            []
+            [],
         ],
         [
             [streamer_a, streamer_b, streamer_c],
             1,
             StreamerSource.Streamers,
             [streamer_a, streamer_c],
-            ["a"]
+            ["a"],
         ],
         [
             [streamer_a, streamer_b, streamer_c],
             2,
             StreamerSource.Streamers,
             [streamer_a, streamer_c],
-            ["a", "c"]
+            ["a", "c"],
         ],
         [
             [streamer_a, streamer_b, streamer_c],
             3,
             StreamerSource.Streamers,
             [streamer_a, streamer_c],
-            ["a", "c"]
+            ["a", "c"],
         ],
         # StreamerSource.Followers
         [
@@ -801,50 +944,38 @@ class TestPriorityGroupSelector:
             0,
             StreamerSource.Followers,
             [streamer_b],
-            []
+            [],
         ],
         [
             [streamer_a, streamer_b, streamer_c],
             1,
             StreamerSource.Followers,
             [streamer_b],
-            ["b"]
+            ["b"],
         ],
         [
             [streamer_a, streamer_b, streamer_c],
             2,
             StreamerSource.Followers,
             [streamer_b],
-            ["b"]
+            ["b"],
         ],
         [
             [streamer_a, streamer_b, streamer_c],
             3,
             StreamerSource.Followers,
             [streamer_b],
-            ["b"]
+            ["b"],
         ],
         # Arbitrary Callable Filter
-        [
-            [streamer_a, streamer_b, streamer_c],
-            0,
-            lambda s: s.channel_id in [],
-            [],
-            []
-        ],
-        [
-            [streamer_a, streamer_b, streamer_c],
-            1,
-            lambda s: s.channel_id in [],
-            [],
-            []
-        ],
+        [[streamer_a, streamer_b, streamer_c], 0, lambda s: s.channel_id in [], [], []],
+        [[streamer_a, streamer_b, streamer_c], 1, lambda s: s.channel_id in [], [], []],
         [
             [streamer_a, streamer_b, streamer_c],
             1,
             lambda s: s.channel_id in ["d"],
             [],
-            []
+            [],
         ],
         [
             [streamer_a, streamer_b, streamer_c],
@@ -852,7 +983,8 @@ class TestPriorityGroupSelector:
             lambda s: s.channel_id in ["a", "b", "c"],
             [streamer_a, streamer_b, streamer_c],
             ["a", "b"],
-        ],        [
+        ],
+        [
             [streamer_a, streamer_b, streamer_c],
             2,
             lambda s: s.channel_id in ["b", "c"],
@@ -1089,7 +1221,8 @@ priority_streak_by_earliest_stream_created_at_data = [
 
 
 @pytest.mark.parametrize(
-    "streamers,max_amount,expected_ids", priority_streak_by_earliest_stream_created_at_data
+    "streamers,max_amount,expected_ids",
+    priority_streak_by_earliest_stream_created_at_data,
 )
 def test_priority_streak_by_earliest_stream_created_at(
     streamers: list[Streamer], max_amount: int, expected_ids: list[str]


### PR DESCRIPTION
# Description

Fixes #17 

Adds `StreamerSettings.points_limit`. When set to an `int`, the channel will not be selected for  `ORDER`, `POINTS_ASCENDING`, `POINTS_DESCENDING`, and `SUBSCRIBED` priorities. When set to `False`, no limit is applied and the Streamer will always be considered for any priority. This is the default which is the current miner behaviour.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

New unit tests plus live testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
