### PR TITLE
PlaybackAccessToken Refresh

### DIFF
--- a/TwitchChannelPointsMiner/classes/PubSub.py
+++ b/TwitchChannelPointsMiner/classes/PubSub.py
@@ -79,6 +79,9 @@ class PubSubHandler(MessageListener):
                     earned = message.data["point_gain"]["total_points"]
                     reason_code = message.data["point_gain"]["reason_code"]
 
+                    if reason_code == "WATCH":
+                        streamer.stream.watch_session_state = None
+
                     logger.info(
                         f"+{earned} → {streamer} - Reason: {reason_code}.",
                         extra={

--- a/TwitchChannelPointsMiner/classes/Settings.py
+++ b/TwitchChannelPointsMiner/classes/Settings.py
@@ -8,6 +8,7 @@ class Priority(Enum):
     SUBSCRIBED = auto()
     POINTS_ASCENDING = auto()
     POINTS_DESCENDING = auto()
+    WATCH_SESSION = auto()
 
 
 class StreamerSource(StrEnum):

--- a/TwitchChannelPointsMiner/classes/StreamerSelector.py
+++ b/TwitchChannelPointsMiner/classes/StreamerSelector.py
@@ -1,6 +1,8 @@
 import abc
+import datetime
 import logging
 import time
+from itertools import islice
 from typing import Protocol, Sequence, Callable
 
 from TwitchChannelPointsMiner.classes.Settings import Priority, StreamerSource
@@ -88,6 +90,34 @@ def priority_subscribed(streamers: Sequence[Streamer], max_amount: int) -> list[
     return [streamer.channel_id for streamer in streamers_with_multiplier[:max_amount]]
 
 
+def priority_watch(streamers: Sequence[Streamer], max_amount: int) -> list[str]:
+    """
+    Returns streamer ids that have yet to receive a WATCH for a watch attempt session, where the session has been less than
+    7 minutes.
+    :param streamers: The Streamers from which to select.
+    :param max_amount: The maximum amount of streamer ids to select.
+    :return: The selected streamer ids.
+    """
+
+    return list(
+        islice(
+            (
+                streamer.channel_id
+                for streamer in streamers
+                if streamer.stream.watch_session_state is not None
+                   and (
+                    (
+                        datetime.datetime.now(datetime.timezone.utc)
+                        - streamer.stream.watch_session_state
+                    ).total_seconds()
+                    <= 60 * 7
+                )
+            ),
+            max_amount,
+        )
+    )
+
+
 class PriorityFunction(Protocol):
     def __call__(self, streamers: Sequence[Streamer], max_amount: int) -> list[str]: ...
 
@@ -99,6 +129,7 @@ priority_functions: dict[Priority, PriorityFunction] = {
     Priority.STREAK: priority_streak,
     Priority.DROPS: priority_drops,
     Priority.SUBSCRIBED: priority_subscribed,
+    Priority.WATCH_SESSION: priority_watch,
 }
 
 
@@ -132,6 +163,7 @@ class PrioritySelector(StreamerSelector):
                 to_add = self.priority_functions[priority](
                     list(unselected.values()), selected.remaining()
                 )
+                logger.debug(f"Selecting {to_add} for {priority}")
                 if not selected.add(*to_add):
                     break
                 else:

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -604,6 +604,29 @@ class Twitch(object):
                     find_streamer(streamer_id) for streamer_id in selected_streamer_ids
                 ]
 
+                # Log the difference, if any
+                selected_set = set(selected_streamer_ids)
+                if watched_previous_iteration != selected_set:
+                    dropping = list(
+                        str(find_streamer(channel_id))
+                        for channel_id in watched_previous_iteration - selected_set
+                    )
+                    adding = list(
+                        str(find_streamer(channel_id))
+                        for channel_id in selected_set - watched_previous_iteration
+                    )
+                    logger.debug(
+                        f"Changing watch slots: Adding {adding}, Dropping {dropping}"
+                    )
+
+                # Update the watch session state before starting the watch loop
+                for streamer in streamers_watching:
+                    if streamer.stream.watch_session_state is None:
+                        # We've started a new session
+                        streamer.stream.watch_session_state = datetime.datetime.now(
+                            datetime.timezone.utc
+                        )
+
                 watch_attempts_start_time = time.time()
 
                 for streamer in streamers_watching:

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -390,22 +390,26 @@ class Twitch(object):
             return self.client_session.version
 
     def get_or_update_playback_access_token(
-        self, streamer: Streamer
+        self, streamer: Streamer, force_refresh_token: bool
     ) -> PlaybackAccessToken | None:
         """
         Gets a PlaybackAccessToken for the current Stream for the given Streamer. This may involve making a GQL
         request for a new token if one doesn't exist or the current one has expired.
 
         :param streamer: The Streamer for which to get the token.
+        :param force_refresh_token: If True, the playback token will be refreshed.
         :return: The token or None if one could not be obtained.
         """
-        if streamer.settings.simulate_hls_playback is not False and (
-            streamer.stream.playback_access_token is None
-            or (
-                streamer.stream.playback_access_token.value.expires
-                - datetime.datetime.now(datetime.UTC)
-            ).total_seconds()
-            <= streamer.settings.simulate_hls_playback.refresh_before
+        if force_refresh_token or (
+            streamer.settings.simulate_hls_playback is not False
+            and (
+                streamer.stream.playback_access_token is None
+                or (
+                    streamer.stream.playback_access_token.value.expires
+                    - datetime.datetime.now(datetime.UTC)
+                ).total_seconds()
+                <= streamer.settings.simulate_hls_playback.refresh_before
+            )
         ):
             try:
                 gql_token = self.gql.get_playback_access_token(streamer.username)
@@ -422,15 +426,18 @@ class Twitch(object):
                 return None
         return streamer.stream.playback_access_token
 
-    def get_hls_playlist_url(self, streamer: Streamer) -> str | None:
+    def get_hls_playlist_url(
+        self, streamer: Streamer, force_refresh_token: bool
+    ) -> str | None:
         """
         Gets the playlist URL for the current Stream for the given Streamer.
 
         :param streamer: The Streamer for which to get the URL.
+        :param force_refresh_token: If True, the playback token will be refreshed.
         :return: The URL or None if one could not be obtained.
         """
 
-        token = self.get_or_update_playback_access_token(streamer)
+        token = self.get_or_update_playback_access_token(streamer, force_refresh_token)
         if token is None:
             return None
 
@@ -469,12 +476,15 @@ class Twitch(object):
         streamer.stream.hls_url = lowest_quality_playlist_url
         return lowest_quality_playlist_url
 
-    def simulate_hls_playback(self, streamer: Streamer) -> bool:
+    def simulate_hls_playback(
+        self, streamer: Streamer, force_refresh_token: bool
+    ) -> bool:
         """
         Simulates the HLS playback for the current Stream for the given Streamer by making a HEAD request to the latest
         stream segment.
 
         :param streamer: The Streamer for which to simulate playback.
+        :param force_refresh_token: If True, the playback token will be refreshed.
         :return: True if playback succeeded, False otherwise.
         """
         # Twitch serves Streams via HLS which is based on M3U8 playlists. To "play back" a part of a stream you can:
@@ -487,7 +497,7 @@ class Twitch(object):
         # because the contents of the Lowest Quality Stream Playlist changes at least every 2 seconds.
 
         # Get the segment playlist URL for the lowest quality stream option
-        stream_playlist_url = self.get_hls_playlist_url(streamer)
+        stream_playlist_url = self.get_hls_playlist_url(streamer, force_refresh_token)
         if stream_playlist_url is None:
             return False
 
@@ -566,6 +576,9 @@ class Twitch(object):
                 f"Streamer with channel_id ({channel_id}) not found in streamer list."
             )
 
+        watched_previous_iteration = set()
+        watched_this_iteration = set()
+
         while self.running:
             try:
                 online_streamers = [
@@ -601,11 +614,15 @@ class Twitch(object):
                     try:
                         if (
                             streamer.settings.simulate_hls_playback
-                            and not self.simulate_hls_playback(streamer)
+                            and not self.simulate_hls_playback(
+                                streamer,
+                                streamer.channel_id not in watched_previous_iteration,
+                            )
                         ):
                             continue
 
                         if self.send_spade_minute_watched_event(streamer):
+                            watched_this_iteration.add(streamer.channel_id)
                             streamer.stream.update_minute_watched()
 
                             """
@@ -668,6 +685,8 @@ class Twitch(object):
                 logger.error("Exception raised in send minute watched", exc_info=True)
                 # Do a short sleep to avoid error log spam
                 time.sleep(1)
+            watched_previous_iteration = watched_this_iteration
+            watched_this_iteration = set()
 
     # === CHANNEL POINTS / PREDICTION === #
     # Load the amount of current points for a channel, check if a bonus is available

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -399,15 +399,19 @@ class Twitch(object):
         :param streamer: The Streamer for which to get the token.
         :return: The token or None if one could not be obtained.
         """
-        if (
+        if streamer.settings.simulate_hls_playback is not False and (
             streamer.stream.playback_access_token is None
-            or streamer.stream.playback_access_token.value.expires
-            <= datetime.datetime.now(datetime.UTC)
+            or (
+                streamer.stream.playback_access_token.value.expires
+                - datetime.datetime.now(datetime.UTC)
+            ).total_seconds()
+            <= streamer.settings.simulate_hls_playback.refresh_before
         ):
             try:
                 gql_token = self.gql.get_playback_access_token(streamer.username)
                 token = PlaybackAccessToken.from_gql(gql_token)
                 streamer.stream.playback_access_token = token
+                streamer.stream.hls_url = None
                 logger.debug(
                     f"Obtained PlaybackAccessToken for {streamer.username}, expires {token.value.expires}"
                 )
@@ -425,12 +429,13 @@ class Twitch(object):
         :param streamer: The Streamer for which to get the URL.
         :return: The URL or None if one could not be obtained.
         """
-        if streamer.stream.hls_url is not None:
-            return streamer.stream.hls_url
 
         token = self.get_or_update_playback_access_token(streamer)
         if token is None:
             return None
+
+        if streamer.stream.hls_url is not None:
+            return streamer.stream.hls_url
 
         # Construct the URL for the broadcast qualities
         master_playlist_url = f"https://usher.ttvnw.net/api/channel/hls/{streamer.username}.m3u8?sig={token.signature}&token={token.raw_value}"

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -585,10 +585,6 @@ class Twitch(object):
                     streamer
                     for streamer in streamers
                     if streamer.is_online is True
-                    and (
-                        streamer.online_at == 0
-                        or (time.time() - streamer.online_at) > 30
-                    )
                     and streamer.channel_points_enabled
                     and not streamer.chat_banned
                 ]

--- a/TwitchChannelPointsMiner/classes/entities/Stream.py
+++ b/TwitchChannelPointsMiner/classes/entities/Stream.py
@@ -41,6 +41,7 @@ class Stream(object):
         "__last_update",
         "__minute_watched_timestamp",
         "created_at",
+        "watch_session_state",
     ]
 
     def __init__(self):
@@ -65,6 +66,10 @@ class Stream(object):
         """The URL of the HLS stream playlist for this Stream."""
 
         self.created_at: datetime | None = None
+
+        # Start as None as we've yet to begin a watch session
+        self.watch_session_state: datetime | None = None
+        """The start time of the current watch session or None if we haven't started a session since the last WATCH."""
 
         self.init_watch_streak()
 

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -4,6 +4,7 @@ import os
 import time
 from datetime import datetime
 from threading import Lock
+from typing import Literal
 
 from TwitchChannelPointsMiner.classes.Chat import ChatPresence, ThreadChat
 from TwitchChannelPointsMiner.classes.Settings import Events, Settings, StreamerSource
@@ -13,9 +14,18 @@ from TwitchChannelPointsMiner.classes.entities.Stream import Stream
 from TwitchChannelPointsMiner.classes.gql import Properties
 from TwitchChannelPointsMiner.constants import URL
 from TwitchChannelPointsMiner.utils import millify
-from TwitchChannelPointsMiner.utils.Utils import oxford_comma_list
+from TwitchChannelPointsMiner.utils.Utils import oxford_comma_list, simple_repr
 
 logger = logging.getLogger(__name__)
+
+
+class HLSSettings:
+    def __init__(self, refresh_before: int):
+        self.refresh_before = refresh_before
+        """ The number of seconds, before a token expires, to refresh it. """
+
+    def __repr__(self):
+        return simple_repr(self)
 
 
 class StreamerSettings(object):
@@ -41,7 +51,7 @@ class StreamerSettings(object):
         community_goals: bool = None,
         bet: BetSettings = None,
         chat: ChatPresence = None,
-        simulate_hls_playback: bool = None,
+        simulate_hls_playback: Literal[False] | HLSSettings | None = None,
     ):
         self.make_predictions = make_predictions
         self.follow_raid = follow_raid
@@ -52,7 +62,10 @@ class StreamerSettings(object):
         self.bet = bet
         self.chat = chat
         self.simulate_hls_playback = simulate_hls_playback
-        """If True, simulates playback of the stream via HLS when selected to watch."""
+        """
+        Simulates playback of the stream via HLS when selected to watch.
+        If False, the miner won't perform HLS simulation.
+        """
 
     def default(self):
         for name in [
@@ -61,7 +74,6 @@ class StreamerSettings(object):
             "claim_drops",
             "claim_moments",
             "watch_streak",
-            "simulate_hls_playback",
         ]:
             if getattr(self, name) is None:
                 setattr(self, name, True)
@@ -71,9 +83,11 @@ class StreamerSettings(object):
             self.bet = BetSettings()
         if self.chat is None:
             self.chat = ChatPresence.ONLINE
+        if self.simulate_hls_playback is None:
+            self.simulate_hls_playback = HLSSettings(refresh_before=2 * 60)
 
     def __repr__(self):
-        return f"StreamerSettings(make_predictions={self.make_predictions}, follow_raid={self.follow_raid}, claim_drops={self.claim_drops}, claim_moments={self.claim_moments}, watch_streak={self.watch_streak}, community_goals={self.community_goals}, bet={self.bet}, chat={self.chat}, simulate_m3u8={self.simulate_m3u8})"
+        return f"StreamerSettings(make_predictions={self.make_predictions}, follow_raid={self.follow_raid}, claim_drops={self.claim_drops}, claim_moments={self.claim_moments}, watch_streak={self.watch_streak}, community_goals={self.community_goals}, bet={self.bet}, chat={self.chat}, simulate_hls_playback={self.simulate_hls_playback})"
 
 
 class Streamer(object):


### PR DESCRIPTION
# Description

Fixed a bug where `PlaybackAccessToken` expiration was not respected. The number of seconds before token refresh is now configurable, defaults to 2 mins before expiration.

Fixes #25 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally with 3 options: default configuration (-2 mins), -15 mins refresh, and no HLS simulation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
